### PR TITLE
executor: Move CPU core binding operation under `fuzzuf::Util`

### DIFF
--- a/algorithms/aflfast/aflfast_state.cpp
+++ b/algorithms/aflfast/aflfast_state.cpp
@@ -616,16 +616,16 @@ void AFLFastState::ShowStats(void) {
 
     /* Provide some CPU utilization stats. */
 
-    if (executor->cpu_core_count) {
+    if (cpu_core_count) {
         double cur_runnable = GetRunnableProcesses(*this);
-        u32 cur_utilization = cur_runnable * 100 / executor->cpu_core_count;
+        u32 cur_utilization = cur_runnable * 100 / cpu_core_count;
 
         std::string cpu_color = cCYA;
 
         /* If we could still run one or more processes, use green. */
 
-        if (executor->cpu_core_count > 1 &&
-            cur_runnable + 1 <= executor->cpu_core_count)
+        if (cpu_core_count > 1 &&
+            cur_runnable + 1 <= cpu_core_count)
             cpu_color = cLGN;
 
         /* If we're clearly oversubscribed, use red. */
@@ -634,9 +634,9 @@ void AFLFastState::ShowStats(void) {
 
 #ifdef HAVE_AFFINITY
 
-        if (executor->binded_cpuid.has_value()) {
+        if (cpu_aff >= 0) {
             MSG(SP10 cGRA "[cpu%03d:%s%3u%%" cGRA "]\r" cRST,
-                 std::min(executor->binded_cpuid.value(), 999),
+                 std::min(cpu_aff, 999),
                  cpu_color.c_str(), std::min(cur_utilization, 999u));
         } else {
             MSG(SP10 cGRA "   [cpu:%s%3u%%" cGRA "]\r" cRST,

--- a/algorithms/die/die_state.cpp
+++ b/algorithms/die/die_state.cpp
@@ -862,16 +862,16 @@ void DIEState::ShowStats(void) {
 
   /* Provide some CPU utilization stats. */
 
-  if (executor->cpu_core_count) {
+  if (cpu_core_count) {
     double cur_runnable = GetRunnableProcesses(*this);
-    u32 cur_utilization = cur_runnable * 100 / executor->cpu_core_count;
+    u32 cur_utilization = cur_runnable * 100 / cpu_core_count;
 
     std::string cpu_color = cCYA;
 
     /* If we could still run one or more processes, use green. */
 
-    if (executor->cpu_core_count > 1 &&
-        cur_runnable + 1 <= executor->cpu_core_count)
+    if (cpu_core_count > 1 &&
+        cur_runnable + 1 <= cpu_core_count)
       cpu_color = cLGN;
 
     /* If we're clearly oversubscribed, use red. */
@@ -880,9 +880,9 @@ void DIEState::ShowStats(void) {
 
 #ifdef HAVE_AFFINITY
 
-    if (executor->binded_cpuid.has_value()) {
+    if (cpu_aff >= 0) {
       MSG(SP20 SP20 SP20 SP5 cGRA "[cpu%03d:%s%3u%%" cGRA "]\r" cRST,
-          std::min(executor->binded_cpuid.value(), 999),
+          std::min(cpu_aff, 999),
           cpu_color.c_str(), std::min(cur_utilization, 999u));
     } else {
       MSG(SP20 SP20 SP20 SP5 cGRA "   [cpu:%s%3u%%" cGRA "]\r" cRST,

--- a/executor/coresight_executor.cpp
+++ b/executor/coresight_executor.cpp
@@ -29,10 +29,9 @@ CoreSightExecutor::CoreSightExecutor(
     bool forksrv,
     const fs::path &path_to_write_input,
     u32 afl_shm_size,
-    int cpuid_to_bind,
     bool record_stdout_and_err
 ) : ProxyExecutor ( proxy_path, std::vector<std::string>(), argv, exec_timelimit_ms, exec_memlimit, forksrv,
-                    path_to_write_input, afl_shm_size, 0, cpuid_to_bind, record_stdout_and_err )
+                    path_to_write_input, afl_shm_size, 0, record_stdout_and_err )
 {
     ProxyExecutor::SetCArgvAndDecideInputMode();
     ProxyExecutor::Initilize();

--- a/executor/native_linux_executor.cpp
+++ b/executor/native_linux_executor.cpp
@@ -47,22 +47,6 @@ NativeLinuxExecutor* NativeLinuxExecutor::active_instance = nullptr;
  *   - A file can be created at path path_str_to_write_input.
  * Postcondition:
  *     - Run process below in order, with initializing members
- *       * Depending on the args, CPU cores to run both this process and the descendant processes need to be specified. There are three method to specify:
- *         1. Pass NativeLinuxExecutor::CPUID_DO_NOT_BIND to cpu_to_bind to specify nothing.
- *         2. Pass integer value in [0, cpu core count) to cpu_to_bind to specify core number.
- *         3. Pass NativeLinuxExecutor::CPUID BIND_WHICHEVER then this class looks for free cores and select it.
- *
- *         - Note1 (definition) :
- *           * Binding process P (and thats descendant) to core a means that process p (and thats descendant) is warrantied running on core a and other FUZZUF related processes never run on core a.
- *           * Currently, it is just a functionality depending on sched_setaffinity on Linux, and in precise word, it is a functionality that limit core which has permission to run to just one using sched_setaffinity.
- *          Refer man pages and Util::GetFreeCpu if you wonder that works properly as described in definition.
- *           * Therefore, this procedure is executed only on Linux
- *         - Note2 (The reason Executor having this functionality)
- *           * Limiting CPU cores is NativeLinuxExecutor specific operation that algorithms should not care.
- *           * Therefore this Executor should handle it.
- *           * On the other hand, this procedure affects whole the process. In simple word, it requires only 1 executor existing in 1 process.
- *           * As the future work, the class managing CPU cores and executors should be introduced for solving this limitation.
- *           * For the time being, 3 options which cover all situation are provided.
  *       * Configure signal handlers (Temporary workaround for non fork server mode. This will be removed in future.)
  *       * Parsing and preprocessing of commandline arguments of PUT.
  *       * Generate a file for sending input to  PUT.
@@ -73,6 +57,7 @@ NativeLinuxExecutor* NativeLinuxExecutor::active_instance = nullptr;
  *         - In kernel, Both parameters are round up to multiple of PAGE_SIZE, then memory is allocated.
  *       * Configure environment variables for PUT
  *       * If fork server mode, launch fork server.
+ *       * NOTE: Executor does not take care about binding a CPU core. The owner fuzzing algorithm is responsible to it.
  */
 NativeLinuxExecutor::NativeLinuxExecutor(  
     const std::vector<std::string> &argv,
@@ -82,17 +67,14 @@ NativeLinuxExecutor::NativeLinuxExecutor(
     const fs::path &path_to_write_input,
     u32 afl_shm_size,
     u32  bb_shm_size,
-    int cpuid_to_bind,  // FIXME: Add tests against binding(How is it tested?）
     bool record_stdout_and_err
 ) :
     Executor( argv, exec_timelimit_ms, exec_memlimit, path_to_write_input.string() ),
     forksrv( forksrv ),
     afl_shm_size( afl_shm_size ),
     bb_shm_size( bb_shm_size ),
-    binded_cpuid( std::nullopt ),
 
     // cargv and stdin_mode are initialized at SetCArgvAndDecideInputMode
-    cpu_core_count( Util::GetCpuCore() ), // This is a temporary implementation. Change the implementation properly if the value need to be specified from user side.
     bb_shmid( INVALID_SHMID ),
     afl_shmid( INVALID_SHMID ),
     forksrv_pid( 0 ),
@@ -103,45 +85,6 @@ NativeLinuxExecutor::NativeLinuxExecutor(
     child_timed_out( false ),
     record_stdout_and_err( record_stdout_and_err )
 {
-
-#ifdef __linux__
-    // If cpuid_to_bind is not CPUID_DO_NOT_BIND,
-    // then the executor tries to bind this process to a cpu core somehow
-    if (cpuid_to_bind != CPUID_DO_NOT_BIND) {
-        std::set<int> vacant_cpus = Util::GetFreeCpu(cpu_core_count); 
-
-        if (cpuid_to_bind == CPUID_BIND_WHICHEVER) { 
-            // this means "don't care which cpu core, but should bind"
-
-            if (vacant_cpus.empty()) {
-                ERROR("No more free CPU cores");
-            }
-
-            binded_cpuid = *vacant_cpus.begin(); // just return a random number
-        } else { 
-            if (cpuid_to_bind < 0 || cpu_core_count <= cpuid_to_bind) {
-                ERROR("The CPU core id to bind should be between 0 and %d", cpu_core_count - 1);
-            }
-
-            if (vacant_cpus.count(cpuid_to_bind) == 0) {
-                ERROR("The CPU core #%d to bind is not free!", cpuid_to_bind);
-            }
-
-            binded_cpuid = cpuid_to_bind;
-        }
-
-        cpu_set_t c;
-        CPU_ZERO(&c);
-        CPU_SET(binded_cpuid.value(), &c);
-
-        if (sched_setaffinity(0, sizeof(c), &c)) ERROR("sched_setaffinity failed");
-    }
-#else 
-    if (cpuid_to_bind != CPUID_DO_NOT_BIND) {
-        DEBUG("In this environment, processes cannot be binded to a cpu core.");
-    }
-#endif /* __linux__ */
-
     if (!has_setup_sighandlers) {
 	// For the time being, as signal handler is set globally, this function is static method, therefore it is not needed to set again if has_setup_handlers is ture.
         SetupSignalHandlers();

--- a/executor/pt_executor.cpp
+++ b/executor/pt_executor.cpp
@@ -28,10 +28,9 @@ PTExecutor::PTExecutor(
     u64 exec_memlimit,
     bool forksrv,
     const fs::path &path_to_write_input,
-    int cpuid_to_bind,
     bool record_stdout_and_err
 ) : ProxyExecutor ( proxy_path, std::vector<std::string>(), argv, exec_timelimit_ms, exec_memlimit, forksrv,
-                    path_to_write_input, 0, 0, cpuid_to_bind, record_stdout_and_err ),
+                    path_to_write_input, 0, 0, record_stdout_and_err ),
     path_shm_size ( PTExecutor::PATH_SHM_SIZE ),
     fav_shm_size ( PTExecutor::FAV_SHM_SIZE )
 {

--- a/executor/qemu_executor.cpp
+++ b/executor/qemu_executor.cpp
@@ -28,10 +28,9 @@ QEMUExecutor::QEMUExecutor(
     u64 exec_memlimit,
     bool forksrv,
     const fs::path &path_to_write_input,
-    int cpuid_to_bind,
     bool record_stdout_and_err
 ) : ProxyExecutor ( proxy_path, std::vector<std::string>(), argv, exec_timelimit_ms, exec_memlimit, forksrv,
-                    path_to_write_input, QEMUExecutor::QEMU_SHM_SIZE, 0, cpuid_to_bind, record_stdout_and_err )
+                    path_to_write_input, QEMUExecutor::QEMU_SHM_SIZE, 0, record_stdout_and_err )
 {
     ProxyExecutor::SetCArgvAndDecideInputMode();
     ProxyExecutor::Initilize();

--- a/include/fuzzuf/algorithms/afl/afl_state.hpp
+++ b/include/fuzzuf/algorithms/afl/afl_state.hpp
@@ -303,6 +303,12 @@ struct AFLStateTemplate {
     u64 total_bitmap_size = 0;              /* Total bit count for all bitmaps  */
     u64 total_bitmap_entries = 0;           /* Number of bitmaps counted        */
 
+    /* CPU core count                   */
+    int cpu_core_count;
+
+    /* Selected CPU core                */
+    int cpu_aff;
+
     /* Fuzzing queue (vector)           */
     std::vector<std::shared_ptr<Testcase>> case_queue;
 

--- a/include/fuzzuf/algorithms/libfuzzer/config.hpp
+++ b/include/fuzzuf/algorithms/libfuzzer/config.hpp
@@ -139,7 +139,13 @@ auto toString(std::string &dest, const Config &value, std::size_t indent_count,
               const std::string &indent) -> bool;
 
 struct FuzzerCreateInfo {
-  FuzzerCreateInfo() : input_dir("./input"), output_dir("./output") {}
+  FuzzerCreateInfo()
+    : input_dir("./input"),
+      output_dir("./output"),
+      // This is a temporary implementation. Change the implementation
+      // properly if the value need to be specified from user side.
+      cpu_core_count(Util::GetCpuCore()),
+      cpu_aff(Util::BindCpu(cpu_core_count, cpuid_to_bind)) {}
   FUZZUF_SETTER(input_dir)
   FUZZUF_SETTER(output_dir)
   FUZZUF_SETTER(dictionaries)
@@ -158,6 +164,8 @@ struct FuzzerCreateInfo {
   FUZZUF_SETTER(afl_shm_size)
   FUZZUF_SETTER(bb_shm_size)
   FUZZUF_SETTER(cpuid_to_bind)
+  FUZZUF_SETTER(cpu_core_count)
+  FUZZUF_SETTER(cpu_aff)
   FUZZUF_SETTER(use_afl_coverage)
   FUZZUF_SETTER(sparse_energy_updates)
   FUZZUF_SETTER(crashed_only)
@@ -279,7 +287,17 @@ struct FuzzerCreateInfo {
   /**
    * cpuid restriction to execute the target
    */
-  int cpuid_to_bind = NativeLinuxExecutor::CPUID_DO_NOT_BIND;
+  int cpuid_to_bind = Util::CPUID_DO_NOT_BIND;
+
+  /**
+   * CPU core count
+   */
+  int cpu_core_count = 0;
+
+  /**
+   * Selected CPU core
+   */
+  int cpu_aff = Util::CPUID_DO_NOT_BIND;
 
   /**
    * If true, feature is calculated using AFL compatible coverage

--- a/include/fuzzuf/algorithms/libfuzzer/create.hpp
+++ b/include/fuzzuf/algorithms/libfuzzer/create.hpp
@@ -129,7 +129,7 @@ auto createExecuteAndFeedback(const fs::path &target_path,
       {target_path.string(), output_file_path.string()},
       create_info.exec_timelimit_ms, create_info.exec_memlimit,
       create_info.forksrv, path_to_write_seed, create_info.afl_shm_size,
-      create_info.bb_shm_size, create_info.cpuid_to_bind));
+      create_info.bb_shm_size));
   auto execute_ =
       hf::CreateNode<standard_order::Execute<F, NativeLinuxExecutor, Ord>>(
           std::move(executor_), create_info.use_afl_coverage);

--- a/include/fuzzuf/algorithms/nezha/create.hpp
+++ b/include/fuzzuf/algorithms/nezha/create.hpp
@@ -73,7 +73,7 @@ auto CreateRunSingleTarget(const fs::path &target_path,
       {target_path.string(), output_file_path.string()},
       create_info.exec_timelimit_ms, create_info.exec_memlimit,
       create_info.forksrv, path_to_write_seed, create_info.afl_shm_size,
-      create_info.bb_shm_size, create_info.cpuid_to_bind, true));
+      create_info.bb_shm_size, true));
   auto execute =
       hf::CreateNode<lf::standard_order::Execute<F, NativeLinuxExecutor, Ord>>(
           std::move(executor), create_info.use_afl_coverage);

--- a/include/fuzzuf/cli/fuzzer/afl/build_afl_fuzzer_from_args.hpp
+++ b/include/fuzzuf/cli/fuzzer/afl/build_afl_fuzzer_from_args.hpp
@@ -123,7 +123,7 @@ std::unique_ptr<TFuzzer> BuildAFLFuzzerFromArgs(
                         global_options.exec_memlimit.value_or(GetMemLimit<AFLTag>()),
                         afl_options.forksrv,
                         /* dumb_mode */ false,  // FIXME: add dumb_mode
-                        NativeLinuxExecutor::CPUID_BIND_WHICHEVER
+                        Util::CPUID_BIND_WHICHEVER
                     );
 
     // NativeLinuxExecutor needs the directory specified by "out_dir" to be already set up
@@ -143,8 +143,7 @@ std::unique_ptr<TFuzzer> BuildAFLFuzzerFromArgs(
                         setting->forksrv,
                         setting->out_dir / GetDefaultOutfile<AFLTag>(),
                         GetMapSize<AFLTag>(), // afl_shm_size
-                                           0, //  bb_shm_size
-                        setting->cpuid_to_bind
+                                           0  //  bb_shm_size
                     );
 
     // Create AFLState

--- a/include/fuzzuf/cli/fuzzer/aflfast/build_aflfast_fuzzer_from_args.hpp
+++ b/include/fuzzuf/cli/fuzzer/aflfast/build_aflfast_fuzzer_from_args.hpp
@@ -121,7 +121,7 @@ std::unique_ptr<TFuzzer> BuildAFLFastFuzzerFromArgs(
                         global_options.exec_memlimit.value_or(GetMemLimit<AFLFastTag>()),
                         aflfast_options.forksrv,
                         /* dumb_mode */ false,  // FIXME: add dumb_mode
-                        NativeLinuxExecutor::CPUID_BIND_WHICHEVER,
+                        Util::CPUID_BIND_WHICHEVER,
                         FAST
                     );
 
@@ -142,8 +142,7 @@ std::unique_ptr<TFuzzer> BuildAFLFastFuzzerFromArgs(
                         setting->forksrv,
                         setting->out_dir / GetDefaultOutfile<AFLFastTag>(),
                         GetMapSize<AFLFastTag>(), // afl_shm_size
-                                           0, //  bb_shm_size
-                        setting->cpuid_to_bind
+                                           0      //  bb_shm_size
                     );
 
     // Create AFLFastState

--- a/include/fuzzuf/cli/fuzzer/die/build_die_fuzzer_from_args.hpp
+++ b/include/fuzzuf/cli/fuzzer/die/build_die_fuzzer_from_args.hpp
@@ -167,7 +167,7 @@ std::unique_ptr<TFuzzer> BuildDIEFuzzerFromArgs(FuzzerArgs &fuzzer_args,
     global_options.exec_memlimit.value_or(GetMemLimit<DIETag>()),
     /* forksrv */   true,
     /* dumb_mode */ false,
-    NativeLinuxExecutor::CPUID_BIND_WHICHEVER,
+    Util::CPUID_BIND_WHICHEVER,
     die_options.die_dir, // vvv DIE vvv
     die_options.cmd_py,
     die_options.cmd_node,
@@ -191,8 +191,7 @@ std::unique_ptr<TFuzzer> BuildDIEFuzzerFromArgs(FuzzerArgs &fuzzer_args,
     setting->forksrv,
     setting->out_dir / GetDefaultOutfile<DIETag>(),
     GetMapSize<DIETag>(), // afl_shm_size
-    0, // bb_shm_size
-    setting->cpuid_to_bind
+    0 // bb_shm_size
   );
 
   using fuzzuf::algorithm::die::DIEState;

--- a/include/fuzzuf/cli/fuzzer/ijon/build_ijon_fuzzer_from_args.hpp
+++ b/include/fuzzuf/cli/fuzzer/ijon/build_ijon_fuzzer_from_args.hpp
@@ -119,7 +119,7 @@ std::unique_ptr<TFuzzer> BuildIJONFuzzerFromArgs(
                         global_options.exec_memlimit.value_or(GetMemLimit<IJONTag>()),
                         ijon_options.forksrv,
                         /* dumb_mode */ false,  // FIXME: add dumb_mode
-                        NativeLinuxExecutor::CPUID_BIND_WHICHEVER
+                        Util::CPUID_BIND_WHICHEVER
                     );
 
     // NativeLinuxExecutor needs the directory specified by "out_dir" to be already set up

--- a/include/fuzzuf/executor/coresight_executor.hpp
+++ b/include/fuzzuf/executor/coresight_executor.hpp
@@ -30,7 +30,6 @@ public:
         bool forksrv,
         const fs::path &path_to_write_input,
         u32 afl_shm_size,
-        int cpuid_to_bind,
         // FIXME: see the comment for the same variable in NativeLinuxExecutor
         bool record_stdout_and_err
     );

--- a/include/fuzzuf/executor/native_linux_executor.hpp
+++ b/include/fuzzuf/executor/native_linux_executor.hpp
@@ -46,10 +46,6 @@ public:
 
     static constexpr int INVALID_SHMID = -1; 
 
-    // Constant values used as "cpuid_to_bind", one of the arguments of the constructor
-    static constexpr int CPUID_DO_NOT_BIND    = -2;
-    static constexpr int CPUID_BIND_WHICHEVER = -1;
-
     static constexpr int FORKSRV_FD_READ  = 198;
     static constexpr int FORKSRV_FD_WRITE = 199;
 
@@ -65,13 +61,7 @@ public:
     const u32  afl_shm_size;
     const u32   bb_shm_size;
 
-    // NativeLinuxExecutor may specify a CPU core executing this process (or PUT processes) for speed
-    // If specified, an id in the range 0-origin is assigned. std::nullopt otherwise.
-    std::optional<int> binded_cpuid; 
-
     const bool uses_asan = false; // May become one of the available options in the future, but currently not anticipated
-
-    const int cpu_core_count;
 
     // NativeLinuxExecutor::INVALID_SHMID means not holding valid ID
     int bb_shmid;  
@@ -100,7 +90,6 @@ public:
         const fs::path &path_to_write_input,
         u32 afl_shm_size,
         u32  bb_shm_size,
-        int cpuid_to_bind, 
         // FIXME: The below is a temporary flag to avoid a big performance issue.
         // The issue appears when we save the outputs of stdout/stderr to buffers
         // in every execution of a PUT, which isn't required in most fuzzers.

--- a/include/fuzzuf/executor/proxy_executor.hpp
+++ b/include/fuzzuf/executor/proxy_executor.hpp
@@ -49,10 +49,6 @@ public:
 
     static constexpr int INVALID_SHMID = -1; 
 
-    // Constant values used as "cpuid_to_bind", one of the arguments of the constructor
-    static constexpr int CPUID_DO_NOT_BIND    = -2;
-    static constexpr int CPUID_BIND_WHICHEVER = -1;
-
     static constexpr int FORKSRV_FD_READ  = 198;
     static constexpr int FORKSRV_FD_WRITE = 199;
 
@@ -70,15 +66,7 @@ public:
     const u32  afl_shm_size;
     const u32   bb_shm_size;
 
-    // ProxyExecutor may specify a CPU core executing this process (or PUT processes) for speed
-    // If specified, an id in the range 0-origin is assigned. std::nullopt otherwise.
-    std::optional<int> binded_cpuid; 
-
-    const int cpuid_to_bind;
-
     const bool uses_asan = false; // May become one of the available options in the future, but currently not anticipated
-
-    const int cpu_core_count;
 
     // ProxyExecutor::INVALID_SHMID means not holding valid ID
     int bb_shmid;  
@@ -109,7 +97,6 @@ public:
         const fs::path &path_to_write_input,
         u32 afl_shm_size,
         u32  bb_shm_size,
-        int cpuid_to_bind,
         // FIXME: The below is a temporary flag to avoid a big performance issue.
         // The issue appears when we save the outputs of stdout/stderr to buffers
         // in every execution of a PUT, which isn't required in most fuzzers.

--- a/include/fuzzuf/executor/pt_executor.hpp
+++ b/include/fuzzuf/executor/pt_executor.hpp
@@ -53,7 +53,6 @@ public:
         u64 exec_memlimit,
         bool forksrv,
         const fs::path &path_to_write_input,
-        int cpuid_to_bind,
         // FIXME: see the comment for the same variable in NativeLinuxExecutor
         bool record_stdout_and_err = false
     );

--- a/include/fuzzuf/executor/qemu_executor.hpp
+++ b/include/fuzzuf/executor/qemu_executor.hpp
@@ -32,7 +32,6 @@ public:
         u64 exec_memlimit,
         bool forksrv,
         const fs::path &path_to_write_input,
-        int cpuid_to_bind,
         // FIXME: see the comment for the same variable in NativeLinuxExecutor
         bool record_stdout_and_err = false
     );

--- a/include/fuzzuf/utils/common.hpp
+++ b/include/fuzzuf/utils/common.hpp
@@ -167,8 +167,13 @@ void DeleteFileOrDirectory(std::string path);
 
 int ScanDirAlpha(std::string dir, struct dirent ***namelist);
 
+// Constant values used by `BindCpu()` to indicate CPU binding policy.
+constexpr int CPUID_DO_NOT_BIND = -2;
+constexpr int CPUID_BIND_WHICHEVER = -1;
+
 int GetCpuCore();
 std::set<int> GetFreeCpu(int);
+int BindCpu(int, int);
 
 u64 NextP2(u64);
 

--- a/python/python_fuzzer.cpp
+++ b/python/python_fuzzer.cpp
@@ -111,8 +111,7 @@ PythonFuzzer::PythonFuzzer(
                           setting.forksrv,
                           setting.out_dir / GetDefaultOutfile<PythonTag>(),
                           setting.need_afl_cov ? GetMapSize<PythonTag>() : 0,
-                          setting.need_bb_cov  ? GetMapSize<PythonTag>() : 0, 
-                          NativeLinuxExecutor::CPUID_BIND_WHICHEVER
+                          setting.need_bb_cov  ? GetMapSize<PythonTag>() : 0
     ));
 
     BuildFuzzFlow();
@@ -147,10 +146,7 @@ void PythonFuzzer::Reset(void) {
                           setting.forksrv,
                           setting.out_dir / GetDefaultOutfile<PythonTag>(),
                           setting.need_afl_cov ? GetMapSize<PythonTag>() : 0,
-                          setting.need_bb_cov  ? GetMapSize<PythonTag>(): 0, 
-                          // This process has been already bound.
-                          // Do not bind cpu cores twice.
-                          NativeLinuxExecutor::CPUID_DO_NOT_BIND 
+                          setting.need_bb_cov  ? GetMapSize<PythonTag>(): 0
     ));
 
     BuildFuzzFlow();    

--- a/test/algorithms/afl/loop.cpp
+++ b/test/algorithms/afl/loop.cpp
@@ -62,7 +62,7 @@ static void AFLLoop(bool forksrv) {
       {"../../put_binaries/libjpeg/libjpeg_turbo_fuzzer", "@@"},
       input_dir.native(), output_dir.native(), option::GetExecTimeout<AFLTag>(),
       option::GetMemLimit<AFLTag>(), forksrv, false, /* dumb_mode*/
-      NativeLinuxExecutor::CPUID_BIND_WHICHEVER));
+      Util::CPUID_BIND_WHICHEVER));
 
   // NativeLinuxExecutor needs the directory specified by "out_dir" to be
   // already set up so we need to create the directory first, and then
@@ -74,8 +74,8 @@ static void AFLLoop(bool forksrv) {
       setting->argv, setting->exec_timelimit_ms, setting->exec_memlimit,
       setting->forksrv, setting->out_dir / option::GetDefaultOutfile<AFLTag>(),
       option::GetMapSize<AFLTag>(), // afl_shm_size
-      0,                            //  bb_shm_size
-      setting->cpuid_to_bind);
+      0                             // bb_shm_size
+      );
 
   // Create AFLState
   auto state = std::make_unique<AFLState>(setting, executor);

--- a/test/algorithms/aflfast/loop.cpp
+++ b/test/algorithms/aflfast/loop.cpp
@@ -67,7 +67,7 @@ static void AFLLoop(bool forksrv) {
       input_dir.native(), output_dir.native(),
       option::GetExecTimeout<AFLFastTag>(), option::GetMemLimit<AFLFastTag>(),
       forksrv, false, /* dumb_mode*/
-      NativeLinuxExecutor::CPUID_BIND_WHICHEVER, aflfastoption::FAST));
+      Util::CPUID_BIND_WHICHEVER, aflfastoption::FAST));
 
   // NativeLinuxExecutor needs the directory specified by "out_dir" to be
   // already set up so we need to create the directory first, and then
@@ -80,8 +80,8 @@ static void AFLLoop(bool forksrv) {
       setting->forksrv,
       setting->out_dir / option::GetDefaultOutfile<AFLFastTag>(),
       option::GetMapSize<AFLFastTag>(), // afl_shm_size
-      0,                                //  bb_shm_size
-      setting->cpuid_to_bind);
+      0                                 // bb_shm_size
+      );
 
   // Create AFLFastState
   auto state = std::make_unique<AFLFastState>(setting, executor);

--- a/test/algorithms/die/loop.cpp
+++ b/test/algorithms/die/loop.cpp
@@ -82,7 +82,7 @@ BOOST_AUTO_TEST_CASE(DIELoop) {
       option::GetMemLimit<DIETag>(),
       true,  // forksrv
       false, // dump_mode
-      NativeLinuxExecutor::CPUID_BIND_WHICHEVER,
+      Util::CPUID_BIND_WHICHEVER,
       "../../../tools/die/DIE",      // die_dir
       "python3", "node",             // cmd_py, cmd_node
       path_put.string(), "",         // d8_path, d8_flags
@@ -104,8 +104,7 @@ BOOST_AUTO_TEST_CASE(DIELoop) {
     setting->forksrv,
     setting->out_dir / option::GetDefaultOutfile<DIETag>(),
     option::GetMapSize<DIETag>(), // afl_shm_size
-    0,                            //  bb_shm_size
-    setting->cpuid_to_bind
+    0                             // bb_shm_size
   );
 
   // Create DIEState

--- a/test/algorithms/libfuzzer/execute2.cpp
+++ b/test/algorithms/libfuzzer/execute2.cpp
@@ -128,7 +128,7 @@ BOOST_AUTO_TEST_CASE(HierarFlowExecute) {
         {FUZZUF_FUZZTOYS_DIR "/fuzz_toys-brainf_ck", output_file_path.string()},
         create_info.exec_timelimit_ms, create_info.exec_memlimit,
         create_info.forksrv, path_to_write_seed, create_info.afl_shm_size,
-        create_info.bb_shm_size, create_info.cpuid_to_bind));
+        create_info.bb_shm_size));
     std::size_t solution_count = 0u;
     for (const auto &filename :
          fs::directory_iterator{create_info.output_dir}) {

--- a/test/algorithms/libfuzzer/execute3.cpp
+++ b/test/algorithms/libfuzzer/execute3.cpp
@@ -129,7 +129,7 @@ BOOST_AUTO_TEST_CASE(HierarFlowExecute) {
         {FUZZUF_FUZZTOYS_DIR "/fuzz_toys-brainf_ck", output_file_path.string()},
         create_info.exec_timelimit_ms, create_info.exec_memlimit,
         create_info.forksrv, path_to_write_seed, create_info.afl_shm_size,
-        create_info.bb_shm_size, create_info.cpuid_to_bind));
+        create_info.bb_shm_size));
     std::size_t solution_count = 0u;
     for (const auto &filename :
          fs::directory_iterator{create_info.output_dir}) {

--- a/test/algorithms/libfuzzer/feature.cpp
+++ b/test/algorithms/libfuzzer/feature.cpp
@@ -64,8 +64,7 @@ BOOST_AUTO_TEST_CASE(ExecuteOutput) {
 
   std::unique_ptr<NativeLinuxExecutor> executor(new NativeLinuxExecutor(
       {fuzzuf::utils::which(fs::path("wc")).c_str(), "-c"}, 1000, 10000, false,
-      path_to_write_seed, 65536, 65536, NativeLinuxExecutor::CPUID_DO_NOT_BIND,
-      true));
+      path_to_write_seed, 65536, 65536, true));
 
   lf::InputInfo testcase;
   auto input = lf::test::getSeed1();
@@ -85,8 +84,7 @@ BOOST_AUTO_TEST_CASE(HierarFlowExecuteOutput) {
 
   std::unique_ptr<NativeLinuxExecutor> executor(new NativeLinuxExecutor(
       {fuzzuf::utils::which(fs::path("wc")).c_str(), "-c"}, 1000, 10000, false,
-      path_to_write_seed, 65536, 65536, NativeLinuxExecutor::CPUID_DO_NOT_BIND,
-      true));
+      path_to_write_seed, 65536, 65536, true));
 
   constexpr static auto output_loc = sp::root / sp::arg<1>;
   using Ord =
@@ -118,7 +116,7 @@ BOOST_AUTO_TEST_CASE(ExecuteStatusSuccess) {
 
   std::unique_ptr<NativeLinuxExecutor> executor(new NativeLinuxExecutor(
       {TEST_BINARY_DIR "/executor/ok"}, 1000, 10000, false, path_to_write_seed,
-      65536, 65536, NativeLinuxExecutor::CPUID_DO_NOT_BIND));
+      65536, 65536));
 
   lf::InputInfo testcase;
   auto input = lf::test::getSeed1();
@@ -136,7 +134,7 @@ BOOST_AUTO_TEST_CASE(HierarFlowExecuteStatusSuccess) {
 
   std::unique_ptr<NativeLinuxExecutor> executor(new NativeLinuxExecutor(
       {TEST_BINARY_DIR "/executor/ok"}, 1000, 10000, false, path_to_write_seed,
-      65536, 65536, NativeLinuxExecutor::CPUID_DO_NOT_BIND));
+      65536, 65536));
 
   auto node = hf::CreateNode<lf::standard_order::Execute<
       lf::test::Full, NativeLinuxExecutor, lf::test::Order>>(
@@ -161,8 +159,7 @@ BOOST_AUTO_TEST_CASE(ExecuteStatusAbort) {
 
   std::unique_ptr<NativeLinuxExecutor> executor(
       new NativeLinuxExecutor({TEST_BINARY_DIR "/executor/abort"}, 1000, 10000,
-                              false, path_to_write_seed, 65536, 65536,
-                              NativeLinuxExecutor::CPUID_DO_NOT_BIND));
+                              false, path_to_write_seed, 65536, 65536));
 
   lf::InputInfo testcase;
   auto input = lf::test::getSeed1();
@@ -182,8 +179,7 @@ BOOST_AUTO_TEST_CASE(HierarFlowExecuteAbort) {
 
   std::unique_ptr<NativeLinuxExecutor> executor(
       new NativeLinuxExecutor({TEST_BINARY_DIR "/executor/abort"}, 1000, 10000,
-                              false, path_to_write_seed, 65536, 65536,
-                              NativeLinuxExecutor::CPUID_DO_NOT_BIND));
+                              false, path_to_write_seed, 65536, 65536));
 
   auto node = hf::CreateNode<lf::standard_order::Execute<
       lf::test::Full, NativeLinuxExecutor, lf::test::Order>>(
@@ -209,7 +205,7 @@ BOOST_AUTO_TEST_CASE(ExecuteCoverage) {
   std::unique_ptr<NativeLinuxExecutor> executor(
       new NativeLinuxExecutor({FUZZUF_FUZZTOYS_DIR "/fuzz_toys-brainf_ck"},
                               1000, 10000, false, path_to_write_seed, 65536,
-                              65536, NativeLinuxExecutor::CPUID_DO_NOT_BIND));
+                              65536));
 
   lf::InputInfo testcase;
   std::vector<std::uint8_t> input{'+'};
@@ -230,7 +226,7 @@ BOOST_AUTO_TEST_CASE(HierarFlowExecuteCoverage) {
   std::unique_ptr<NativeLinuxExecutor> executor(
       new NativeLinuxExecutor({FUZZUF_FUZZTOYS_DIR "/fuzz_toys-brainf_ck"},
                               1000, 10000, false, path_to_write_seed, 65536,
-                              65536, NativeLinuxExecutor::CPUID_DO_NOT_BIND));
+                              65536));
 
   auto node = hf::CreateNode<lf::standard_order::Execute<
       lf::test::Full, NativeLinuxExecutor, lf::test::Order>>(

--- a/test/algorithms/libfuzzer/initialize.cpp
+++ b/test/algorithms/libfuzzer/initialize.cpp
@@ -65,7 +65,7 @@ BOOST_AUTO_TEST_CASE(Initialize) {
       new NativeLinuxExecutor({fuzzuf::utils::which(fs::path("tee")).c_str(),
                                output_file_path.native()},
                               1000, 10000, false, path_to_write_seed, 1000,
-                              1000, NativeLinuxExecutor::CPUID_DO_NOT_BIND));
+                              1000));
   BOOST_TEST_CHECKPOINT("after init executor");
 
   namespace lf = fuzzuf::algorithm::libfuzzer;
@@ -153,7 +153,7 @@ BOOST_AUTO_TEST_CASE(HierarFlowExecute) {
       new NativeLinuxExecutor({fuzzuf::utils::which(fs::path("tee")).c_str(),
                                output_file_path.native()},
                               1000, 10000, false, path_to_write_seed, 1000,
-                              1000, NativeLinuxExecutor::CPUID_DO_NOT_BIND));
+                              1000));
 
   BOOST_TEST_CHECKPOINT("after init executor");
 

--- a/test/algorithms/nezha/output_hash2.cpp
+++ b/test/algorithms/nezha/output_hash2.cpp
@@ -137,12 +137,12 @@ BOOST_AUTO_TEST_CASE(HierarFlowOutputHash) {
         {FUZZUF_FUZZTOYS_DIR "/fuzz_toys-csv_small", output_file_path.string()},
         create_info.exec_timelimit_ms, create_info.exec_memlimit,
         create_info.forksrv, path_to_write_seed, create_info.afl_shm_size,
-        create_info.bb_shm_size, create_info.cpuid_to_bind, true));
+        create_info.bb_shm_size, true));
     std::unique_ptr<NativeLinuxExecutor> executor2(new NativeLinuxExecutor(
         {FUZZUF_FUZZTOYS_DIR "/fuzz_toys-csv", output_file_path.string()},
         create_info.exec_timelimit_ms, create_info.exec_memlimit,
         create_info.forksrv, path_to_write_seed, create_info.afl_shm_size,
-        create_info.bb_shm_size, create_info.cpuid_to_bind, true));
+        create_info.bb_shm_size, true));
     std::size_t solution_count = 0u;
     ne::known_outputs_t known;
     for (const auto &filename :

--- a/test/algorithms/nezha/output_hash3.cpp
+++ b/test/algorithms/nezha/output_hash3.cpp
@@ -113,12 +113,12 @@ BOOST_AUTO_TEST_CASE(HierarFlowExecute) {
         {FUZZUF_FUZZTOYS_DIR "/fuzz_toys-csv_small", output_file_path.string()},
         create_info.exec_timelimit_ms, create_info.exec_memlimit,
         create_info.forksrv, path_to_write_seed, create_info.afl_shm_size,
-        create_info.bb_shm_size, create_info.cpuid_to_bind, true));
+        create_info.bb_shm_size, true));
     std::unique_ptr<NativeLinuxExecutor> executor2(new NativeLinuxExecutor(
         {FUZZUF_FUZZTOYS_DIR "/fuzz_toys-csv", output_file_path.string()},
         create_info.exec_timelimit_ms, create_info.exec_memlimit,
         create_info.forksrv, path_to_write_seed, create_info.afl_shm_size,
-        create_info.bb_shm_size, create_info.cpuid_to_bind, true));
+        create_info.bb_shm_size, true));
     std::size_t solution_count = 0u;
     ne::known_outputs_t known;
     for (const auto &filename :

--- a/test/executor/coresight_executor/run.cpp
+++ b/test/executor/coresight_executor/run.cpp
@@ -58,7 +58,6 @@ BOOST_AUTO_TEST_CASE(CoreSightExecutorRun) {
   CoreSightExecutor executor(fs::path(FUZZUF_CS_PROXY_EXECUTABLE),
                              {"/usr/bin/tee", output_file_path.native()}, 1000,
                              10000, true, path_to_write_seed, (1U << 16),
-                             CoreSightExecutor::CPUID_DO_NOT_BIND,
                              true /* record_stdout_and_err */
   );
   BOOST_CHECK_EQUAL(executor.stdin_mode, true);

--- a/test/executor/fork_server_mode/run.cpp
+++ b/test/executor/fork_server_mode/run.cpp
@@ -61,7 +61,7 @@ BOOST_AUTO_TEST_CASE(NativeLinuxExecutorNativeRun) {
   NativeLinuxExecutor executor(
       {TEST_BINARY_DIR "/put_binaries/command_wrapper", "/bin/cat", "@@"}, 1000,
       10000, true, path_to_write_seed, PAGE_SIZE, PAGE_SIZE,
-      NativeLinuxExecutor::CPUID_DO_NOT_BIND, true /* record_stdout_and_err */
+      true /* record_stdout_and_err */
   );
   BOOST_CHECK_EQUAL(executor.stdin_mode, false);
 
@@ -141,7 +141,7 @@ BOOST_AUTO_TEST_CASE(NativeLinuxExecutorNativeRunTooMuchOutput,
       {TEST_BINARY_DIR "/put_binaries/command_wrapper",
        TEST_BINARY_DIR "/executor/too_much_output"},
       1000, 10000, true, path_to_write_seed, PAGE_SIZE, PAGE_SIZE,
-      NativeLinuxExecutor::CPUID_DO_NOT_BIND, true /* record_stdout_and_err */
+      true /* record_stdout_and_err */
   );
   BOOST_CHECK_EQUAL(executor.stdin_mode, true);
 

--- a/test/executor/native_linux_run.cpp
+++ b/test/executor/native_linux_run.cpp
@@ -69,7 +69,7 @@ BOOST_AUTO_TEST_CASE(NativeLinuxExecutorVariableShm) {
     for (u32 bb : checked_sizes) {
       NativeLinuxExecutor executor({"/usr/bin/tee", output_file_path.native()},
                                    1000, 10000, false, path_to_write_seed, afl,
-                                   bb, NativeLinuxExecutor::CPUID_DO_NOT_BIND);
+                                   bb);
 
       std::string input("Hello, World!");
       executor.Run(reinterpret_cast<const u8 *>(input.c_str()), input.size());

--- a/test/executor/non_fork_server_mode/run.cpp
+++ b/test/executor/non_fork_server_mode/run.cpp
@@ -62,7 +62,7 @@ BOOST_AUTO_TEST_CASE(NativeLinuxExecutorNativeRun) {
                                 output_file_path.native()},
                                1000, 10000, false, path_to_write_seed,
                                PAGE_SIZE, PAGE_SIZE,
-                               NativeLinuxExecutor::CPUID_DO_NOT_BIND, true);
+                               true);
   BOOST_CHECK_EQUAL(executor.stdin_mode, true);
 
   // Invoke NativeLinuxExecutor::Run()
@@ -158,8 +158,7 @@ BOOST_AUTO_TEST_CASE(NativeLinuxExecutorNativeRunOk) {
   NativeLinuxExecutor executor(
       //{ "/usr/bin/tee", output_file_path.native() },
       {TEST_BINARY_DIR "/executor/ok", output_file_path.native()}, 1000, 10000,
-      false, path_to_write_seed, PAGE_SIZE, PAGE_SIZE,
-      NativeLinuxExecutor::CPUID_DO_NOT_BIND);
+      false, path_to_write_seed, PAGE_SIZE, PAGE_SIZE);
   BOOST_CHECK_EQUAL(executor.stdin_mode, true);
 
   // Invoke NativeLinuxExecutor::Run()
@@ -201,8 +200,7 @@ BOOST_AUTO_TEST_CASE(NativeLinuxExecutorNativeRunFail) {
   auto path_to_write_seed = output_dir / "cur_input";
   NativeLinuxExecutor executor(
       {TEST_BINARY_DIR "/executor/fail", output_file_path.native()}, 1000,
-      10000, false, path_to_write_seed, PAGE_SIZE, PAGE_SIZE,
-      NativeLinuxExecutor::CPUID_DO_NOT_BIND);
+      10000, false, path_to_write_seed, PAGE_SIZE, PAGE_SIZE);
   BOOST_CHECK_EQUAL(executor.stdin_mode, true);
 
   // Invoke NativeLinuxExecutor::Run()
@@ -244,7 +242,7 @@ BOOST_AUTO_TEST_CASE(NativeLinuxExecutorNativeRunTooMuchOutput,
   NativeLinuxExecutor executor(
       {TEST_BINARY_DIR "/executor/too_much_output"}, 1000, 10000, false,
       path_to_write_seed, PAGE_SIZE, PAGE_SIZE,
-      NativeLinuxExecutor::CPUID_DO_NOT_BIND, true /* record_stdout_and_err */
+      true /* record_stdout_and_err */
   );
   BOOST_CHECK_EQUAL(executor.stdin_mode, true);
 
@@ -287,8 +285,7 @@ BOOST_AUTO_TEST_CASE(NativeLinuxExecutorNativeRunAbort) {
   auto path_to_write_seed = output_dir / "cur_input";
   NativeLinuxExecutor executor(
       {TEST_BINARY_DIR "/executor/abort", output_file_path.native()}, 1000,
-      10000, false, path_to_write_seed, PAGE_SIZE, PAGE_SIZE,
-      NativeLinuxExecutor::CPUID_DO_NOT_BIND);
+      10000, false, path_to_write_seed, PAGE_SIZE, PAGE_SIZE);
   BOOST_CHECK_EQUAL(executor.stdin_mode, true);
 
   // Invoke NativeLinuxExecutor::Run()
@@ -331,8 +328,7 @@ BOOST_AUTO_TEST_CASE(NativeLinuxExecutorNativeRunSegmentationFault) {
   NativeLinuxExecutor executor({TEST_BINARY_DIR "/executor/segmentation_fault",
                                 output_file_path.native()},
                                1000, 10000, false, path_to_write_seed,
-                               PAGE_SIZE, PAGE_SIZE,
-                               NativeLinuxExecutor::CPUID_DO_NOT_BIND);
+                               PAGE_SIZE, PAGE_SIZE);
   BOOST_CHECK_EQUAL(executor.stdin_mode, true);
 
   // Invoke NativeLinuxExecutor::Run()
@@ -374,8 +370,7 @@ BOOST_AUTO_TEST_CASE(NativeLinuxExecutorNativeRunNeverExit) {
   auto path_to_write_seed = output_dir / "cur_input";
   NativeLinuxExecutor executor(
       {TEST_BINARY_DIR "/executor/never_exit", output_file_path.native()}, 1000,
-      10000, false, path_to_write_seed, PAGE_SIZE, PAGE_SIZE,
-      NativeLinuxExecutor::CPUID_DO_NOT_BIND);
+      10000, false, path_to_write_seed, PAGE_SIZE, PAGE_SIZE);
   BOOST_CHECK_EQUAL(executor.stdin_mode, true);
 
   // Invoke NativeLinuxExecutor::Run()
@@ -417,8 +412,7 @@ BOOST_AUTO_TEST_CASE(NativeLinuxExecutorNativeRunNotExists) {
   auto path_to_write_seed = output_dir / "cur_input";
   NativeLinuxExecutor executor(
       {TEST_BINARY_DIR "/executor/not_exists", output_file_path.native()}, 1000,
-      10000, false, path_to_write_seed, PAGE_SIZE, PAGE_SIZE,
-      NativeLinuxExecutor::CPUID_DO_NOT_BIND);
+      10000, false, path_to_write_seed, PAGE_SIZE, PAGE_SIZE);
   BOOST_CHECK_EQUAL(executor.stdin_mode, true);
 
   // Invoke NativeLinuxExecutor::Run()
@@ -460,8 +454,7 @@ BOOST_AUTO_TEST_CASE(NativeLinuxExecutorNativeRunPermissionDenied) {
   auto path_to_write_seed = output_dir / "cur_input";
   NativeLinuxExecutor executor(
       {TEST_DICTIONARY_DIR "/test.dict", output_file_path.native()}, 1000,
-      10000, false, path_to_write_seed, PAGE_SIZE, PAGE_SIZE,
-      NativeLinuxExecutor::CPUID_DO_NOT_BIND);
+      10000, false, path_to_write_seed, PAGE_SIZE, PAGE_SIZE);
   BOOST_CHECK_EQUAL(executor.stdin_mode, true);
 
   // Invoke NativeLinuxExecutor::Run()
@@ -503,8 +496,7 @@ BOOST_AUTO_TEST_CASE(NativeLinuxExecutorNativeRunNotExecutable) {
   auto path_to_write_seed = output_dir / "cur_input";
   NativeLinuxExecutor executor(
       {TEST_SOURCE_DIR "/executor/not_executable", output_file_path.native()},
-      1000, 10000, false, path_to_write_seed, PAGE_SIZE, PAGE_SIZE,
-      NativeLinuxExecutor::CPUID_DO_NOT_BIND);
+      1000, 10000, false, path_to_write_seed, PAGE_SIZE, PAGE_SIZE);
   BOOST_CHECK_EQUAL(executor.stdin_mode, true);
 
   // Invoke NativeLinuxExecutor::Run()

--- a/test/executor/proxy_executor/run.cpp
+++ b/test/executor/proxy_executor/run.cpp
@@ -62,8 +62,7 @@ BOOST_AUTO_TEST_CASE(ProxyExecutorRun) {
   // cannot be empty, we supply output_file_path as a place holder.
   ProxyExecutor executor(fs::path(TEST_BINARY_DIR "/put_binaries/zeroone"), {},
                          {output_file_path.native()}, 1000, 10000, true,
-                         path_to_write_seed, (1U << 16), 0,
-                         ProxyExecutor::CPUID_DO_NOT_BIND, true);
+                         path_to_write_seed, (1U << 16), 0, true);
   // Initialize executor instance
   // We have to run below initialization because ProxyExecutor is considered
   // as a base class and it expects initialization in the derived class constructors.
@@ -161,7 +160,7 @@ BOOST_AUTO_TEST_CASE(ProxyExecutorNativeRunTooMuchOutput,
       {TEST_BINARY_DIR "/executor/too_much_output"},
       {TEST_BINARY_DIR "/executor/too_much_output"}, 1000, 10000, true,
       path_to_write_seed, PAGE_SIZE, PAGE_SIZE,
-      ProxyExecutor::CPUID_DO_NOT_BIND, true /* record_stdout_and_err */
+      true /* record_stdout_and_err */
   );
   // Initialize executor instance
   // We have to run below initialization because ProxyExecutor is considered

--- a/test/executor/qemu_executor/run.cpp
+++ b/test/executor/qemu_executor/run.cpp
@@ -58,7 +58,6 @@ BOOST_AUTO_TEST_CASE(QEMUExecutorRun) {
   QEMUExecutor executor(fs::path(FUZZUF_QEMU_EXECUTABLE),
                         {"/usr/bin/tee", output_file_path.native()}, 1000,
                         10000, true, path_to_write_seed,
-                        QEMUExecutor::CPUID_DO_NOT_BIND,
                         true /* record_stdout_and_err */
   );
   BOOST_CHECK_EQUAL(executor.stdin_mode, true);


### PR DESCRIPTION
<!-- Set a title that summarizes the PR changes. -->

## Type of PR
<!-- This project uses issue-driven development, so please take the appropriate action for each PR type. -->

- [x] Changes related to the roadmap (e.g., TODO.md) (type: A) -> Create an issue corresponding to the PR in advance, and refer to this PR in the issue.
- Changes that are not related to the roadmap
    - [ ] Change with multiple possible solutions to the issue (type: B-1) -> Create an issue corresponding to the PR in advance and refer to this PR in the issue.
    - [ ] Change with a single solution (type: B-2) -> There is no need to create an issue corresponding to the PR in advance. Please discuss it in this PR.

## Related Issue
<!-- If this PR is a PR type A/B-1, please provide a link to the corresponding issue. -->
<!-- If this PR is a PR type B-1, please write "N/A" -->
See #30 

## Importance of PR
<!-- Please describe the importance of the PR in terms of the following aspects. -->

- Importance of the issue
    - [ ] Large (based on several days to weeks of discussion and verification, e.g., this issue is a blocking issue for other issues on the roadmap, etc.)
    - [ ] Medium (based on a few hours to a day of discussion and verification, e.g., this issue is a blocking issue for another minor issue)
    - [x] Small (apparent changes such as build error)
- Complexity of the solution (code, tests, etc.)
    - [ ] Large (requires several days to several weeks of review)
    - [ ] Medium (requires several hours to a day of review)
    - [x] Small (trivial changes, such as build error)

## PR Overview
<!-- Please provide a summary of this PR. -->
<!-- If this PR is a PR type A/B-1, this PR will be considered as an item in the checklist for the related issue. Please provide a link to the issue comment that contains the checklist. -->
<!-- If this PR is a PR type B-2, unnecessary to reference the issue. Please provide a summary. -->
For the background, see issue #30.
This PR proposes splitting CPU core-binding operation from the executors to utility `fuzzuf::Util`. This change is demanded to reduce NativeLinuxExecutor dependencies from fuzzing algorithms. This PR contains executor behavior changes to not binding CPU core itself. The executor owner (usually a fuzzing algorithm) is responsible for explicitly calling `Util::BindCpu` at the initialization.

## Concerns (Optional)
<!-- If you have any concerns, please describe them clearly by filling in the relevant checklist items below. If there is anything else you would like to share with the reviewer, please include it. -->

- [ ] Performance
- [ ] Source Code Quality

---

> The PR author should fill in the following checklist when submitting this PR.

#### Optional Entries
- [x] If this PR is a PR type A/B-1, there is a cross-link between this PR and the related issue.

#### Mandatory Entries
- [x] The PR title is a summary of the changes.
- [x] Completed each required field of the PR.

---
> The PR author should fill out the following checklist in the comments to confirm that this PR is ready to be merged

- [ ] CI is green or confirmed test run results.
- [ ] All change suggestions from reviewers have been resolved (fixed or foregone).

---
> The maintainer of this repository will set up a reviewer for each PR.
> PR reviewers should review this PR in terms of the checklist below before moving on to a detailed code review. Please comment on their initial response by filling in the checklist below.

#### Optional Entries
- [ ] The reviewer assigned more reviewers if needed.
- [ ] The reviewer noted that it is necessary to break out some of the changes in this PR into other PRs if needed.
- [ ] The reviewer noted that the initial response is insufficient if needed.

#### Mandatory Entries
- [ ] The title of this PR summarizes the changes made by this PR properly.
- [ ] The target branch of this PR is as intended.
- [ ] The reviewer understands the issues in this PR.
- [ ] The reviewer plans to review with an appropriate workload based on the importance of this PR.

---
> When the PR reviewer concludes that this PR is ready to be merged, please fill in the checklist below by posting it in the comment. If there is more than one reviewer, please do this on your own.

#### Optional Entries
- [ ] The reviewer noted that if you believe that new tests are needed to evaluate this PR, they have been noted.
- [ ] If minor refactorings are not mentioned in the PR, I understand the intent.
- [ ] If this PR is a PR type A/B-1, we have agreed on this PR's design, direction, and granularity in the related issue.

#### Mandatory Entries
- [ ] The reviewer understands how this PR addresses the issue and the specific changes.
- [ ] This PR uses the best possible issue resolution that the reviewer can think of.
- [ ] This PR is ready to be merged.
