### PR TITLE
executor: Introduce Executor "Trait Objects" by using Type Erasure

### DIFF
--- a/algorithms/aflfast/aflfast_state.cpp
+++ b/algorithms/aflfast/aflfast_state.cpp
@@ -25,7 +25,7 @@ namespace fuzzuf::algorithm::aflfast {
 // FIXME: check if we are initializing all the members that need to be initialized
 AFLFastState::AFLFastState(
     std::shared_ptr<const AFLFastSetting> setting,
-    std::shared_ptr<NativeLinuxExecutor> executor
+    std::shared_ptr<executor::AFLExecutorInterface> executor
 ) : AFLStateTemplate<AFLFastTestcase>(setting, executor),
     setting(setting) {}
 

--- a/algorithms/ijon/ijon_state.cpp
+++ b/algorithms/ijon/ijon_state.cpp
@@ -22,7 +22,7 @@ namespace fuzzuf::algorithm::ijon {
 
 IJONState::IJONState(
     std::shared_ptr<const afl::AFLSetting> setting,
-    std::shared_ptr<NativeLinuxExecutor> executor
+    std::shared_ptr<executor::AFLExecutorInterface> executor
 ) : 
     afl::AFLStateTemplate<IJONTestcase>(setting, executor) {}
 

--- a/algorithms/nautilus/fuzzer/state.cpp
+++ b/algorithms/nautilus/fuzzer/state.cpp
@@ -24,6 +24,7 @@
 #include <iomanip>
 #include <sstream>
 #include "fuzzuf/algorithms/nautilus/fuzzer/state.hpp"
+#include "fuzzuf/exceptions.hpp"
 #include "fuzzuf/feedback/inplace_memory_feedback.hpp"
 #include "fuzzuf/feedback/persistent_memory_feedback.hpp"
 #include "fuzzuf/feedback/put_exit_reason_type.hpp"
@@ -35,7 +36,7 @@ namespace fuzzuf::algorithm::nautilus::fuzzer {
 // MEMO: "this->" is used for members of Fuzzer in original Nautilus
 NautilusState::NautilusState(
     std::shared_ptr<const NautilusSetting> setting,
-    std::shared_ptr<NativeLinuxExecutor> executor
+    std::shared_ptr<executor::AFLExecutorInterface> executor
 ) : setting (setting),
     executor (executor),
     cks (setting->path_to_workdir.string()),

--- a/cli/fuzzers/afl/register_afl_fuzzer.cpp
+++ b/cli/fuzzers/afl/register_afl_fuzzer.cpp
@@ -18,6 +18,7 @@
 #include "fuzzuf/algorithms/afl/afl_fuzzer.hpp"
 #include "fuzzuf/cli/fuzzer_builder_register.hpp"
 #include "fuzzuf/cli/fuzzer/afl/build_afl_fuzzer_from_args.hpp"
+#include "fuzzuf/executor/afl_executor_interface.hpp"
 #include <boost/program_options.hpp>
 
 namespace fuzzuf::algorithm::afl {
@@ -26,6 +27,6 @@ namespace fuzzuf::algorithm::afl {
 // object file.
 // Conversely, if AFL cannot be built in a certain environment, do not compile it into an object file to prevent AFL
 // from being registered by accident.
-static FuzzerBuilderRegister global_afl_register("afl", BuildAFLFuzzerFromArgs<Fuzzer, AFLFuzzer>);
+static FuzzerBuilderRegister global_afl_register("afl", BuildAFLFuzzerFromArgs<Fuzzer, AFLFuzzer, executor::AFLExecutorInterface>);
 
 } // namespace fuzzuf::algorithm::afl

--- a/cli/fuzzers/aflfast/register_aflfast_fuzzer.cpp
+++ b/cli/fuzzers/aflfast/register_aflfast_fuzzer.cpp
@@ -18,6 +18,7 @@
 #include "fuzzuf/algorithms/aflfast/aflfast_fuzzer.hpp"
 #include "fuzzuf/cli/fuzzer_builder_register.hpp"
 #include "fuzzuf/cli/fuzzer/aflfast/build_aflfast_fuzzer_from_args.hpp"
+#include "fuzzuf/executor/afl_executor_interface.hpp"
 
 namespace fuzzuf::algorithm::aflfast {
 
@@ -25,6 +26,6 @@ namespace fuzzuf::algorithm::aflfast {
 // object file.
 // Conversely, if AFL cannot be built in a certain environment, do not compile it into an object file to prevent AFL
 // from being registered by accident.
-static FuzzerBuilderRegister global_afl_register("aflfast", BuildAFLFastFuzzerFromArgs<Fuzzer, AFLFastFuzzer>);
+static FuzzerBuilderRegister global_afl_register("aflfast", BuildAFLFastFuzzerFromArgs<Fuzzer, AFLFastFuzzer, executor::AFLExecutorInterface>);
 
 } // namespace fuzzuf::algorithm::aflfast

--- a/cli/fuzzers/die/register_die_fuzzer.cpp
+++ b/cli/fuzzers/die/register_die_fuzzer.cpp
@@ -23,9 +23,10 @@
 #include "fuzzuf/algorithms/die/die_fuzzer.hpp"
 #include "fuzzuf/cli/fuzzer_builder_register.hpp"
 #include "fuzzuf/cli/fuzzer/die/build_die_fuzzer_from_args.hpp"
+#include "fuzzuf/executor/afl_executor_interface.hpp"
 
 namespace fuzzuf::algorithm::die {
 
-static FuzzerBuilderRegister global_die_register("die", BuildDIEFuzzerFromArgs<Fuzzer, DIEFuzzer>);
+static FuzzerBuilderRegister global_die_register("die", BuildDIEFuzzerFromArgs<Fuzzer, DIEFuzzer, executor::AFLExecutorInterface>);
 
 } // namespace fuzzuf::algorithm::die

--- a/cli/fuzzers/ijon/register_ijon_fuzzer.cpp
+++ b/cli/fuzzers/ijon/register_ijon_fuzzer.cpp
@@ -19,6 +19,7 @@
 #include "fuzzuf/algorithms/ijon/ijon_fuzzer.hpp"
 #include "fuzzuf/cli/fuzzer_builder_register.hpp"
 #include "fuzzuf/cli/fuzzer/ijon/build_ijon_fuzzer_from_args.hpp"
+#include "fuzzuf/executor/afl_executor_interface.hpp"
 
 namespace fuzzuf::cli::fuzzer::ijon {
 
@@ -26,6 +27,6 @@ namespace fuzzuf::cli::fuzzer::ijon {
 // object file.
 // Conversely, if IJON cannot be built in a certain environment, do not compile it into an object file to prevent IJON
 // from being registered by accident.
-static FuzzerBuilderRegister global_ijon_register("ijon", BuildIJONFuzzerFromArgs<Fuzzer, algorithm::ijon::IJONFuzzer>);
+static FuzzerBuilderRegister global_ijon_register("ijon", BuildIJONFuzzerFromArgs<Fuzzer, algorithm::ijon::IJONFuzzer, executor::AFLExecutorInterface>);
 
 } // namespace fuzzuf::cli::fuzzer::ijon

--- a/cli/fuzzers/libfuzzer/register_libfuzzer.cpp
+++ b/cli/fuzzers/libfuzzer/register_libfuzzer.cpp
@@ -18,8 +18,9 @@
 #include "fuzzuf/algorithms/libfuzzer/cli_compat/fuzzer.hpp"
 #include "fuzzuf/cli/fuzzer_builder_register.hpp"
 #include "fuzzuf/cli/fuzzer/libfuzzer/build_libfuzzer_from_args.hpp"
+#include "fuzzuf/executor/libfuzzer_executor_interface.hpp"
 
 namespace fuzzuf::algorithm::libfuzzer {
-  static FuzzerBuilderRegister global_libfuzzer_register("libfuzzer", BuildLibFuzzerFromArgs<Fuzzer, fuzzuf::algorithm::libfuzzer::LibFuzzer>);
+  static FuzzerBuilderRegister global_libfuzzer_register("libfuzzer", BuildLibFuzzerFromArgs<Fuzzer, fuzzuf::algorithm::libfuzzer::LibFuzzer, executor::LibFuzzerExecutorInterface>);
 }
 

--- a/cli/fuzzers/nautilus/register_nautilus_fuzzer.cpp
+++ b/cli/fuzzers/nautilus/register_nautilus_fuzzer.cpp
@@ -18,12 +18,13 @@
 #include "fuzzuf/algorithms/nautilus/fuzzer/fuzzer.hpp"
 #include "fuzzuf/cli/fuzzer_builder_register.hpp"
 #include "fuzzuf/cli/fuzzer/nautilus/build_nautilus_fuzzer_from_args.hpp"
+#include "fuzzuf/executor/afl_executor_interface.hpp"
 
 namespace fuzzuf::cli::fuzzer::nautilus {
 
 static FuzzerBuilderRegister global_nautilus_register(
   "nautilus",
-  BuildNautilusFuzzerFromArgs<Fuzzer, NautilusFuzzer>
+  BuildNautilusFuzzerFromArgs<Fuzzer, NautilusFuzzer, executor::AFLExecutorInterface>
 );
 
 } // namespace fuzzuf::cli::fuzzer::nautilus

--- a/cli/fuzzers/nautilus/register_nautilus_fuzzer.cpp
+++ b/cli/fuzzers/nautilus/register_nautilus_fuzzer.cpp
@@ -19,7 +19,11 @@
 #include "fuzzuf/cli/fuzzer_builder_register.hpp"
 #include "fuzzuf/cli/fuzzer/nautilus/build_nautilus_fuzzer_from_args.hpp"
 
+namespace fuzzuf::cli::fuzzer::nautilus {
+
 static FuzzerBuilderRegister global_nautilus_register(
   "nautilus",
   BuildNautilusFuzzerFromArgs<Fuzzer, NautilusFuzzer>
 );
+
+} // namespace fuzzuf::cli::fuzzer::nautilus

--- a/cli/fuzzers/nezha/register_nezha_fuzzer.cpp
+++ b/cli/fuzzers/nezha/register_nezha_fuzzer.cpp
@@ -18,9 +18,10 @@
 #include "fuzzuf/algorithms/nezha/cli_compat/fuzzer.hpp"
 #include "fuzzuf/cli/fuzzer_builder_register.hpp"
 #include "fuzzuf/cli/fuzzer/nezha/build_nezha_fuzzer_from_args.hpp"
+#include "fuzzuf/executor/libfuzzer_executor_interface.hpp"
 #include <iostream>
 
 namespace fuzzuf::algorithm::nezha {
-  static FuzzerBuilderRegister global_nezha_register("nezha", BuildNezhaFuzzerFromArgs<Fuzzer, fuzzuf::algorithm::nezha::NezhaFuzzer>);
+  static FuzzerBuilderRegister global_nezha_register("nezha", BuildNezhaFuzzerFromArgs<Fuzzer, fuzzuf::algorithm::nezha::NezhaFuzzer, executor::LibFuzzerExecutorInterface>);
 }
 

--- a/include/fuzzuf/algorithms/afl/afl_state.hpp
+++ b/include/fuzzuf/algorithms/afl/afl_state.hpp
@@ -24,7 +24,7 @@
 #include "fuzzuf/utils/common.hpp"
 #include "fuzzuf/utils/filesystem.hpp"
 #include "fuzzuf/exec_input/exec_input_set.hpp"
-#include "fuzzuf/executor/native_linux_executor.hpp"
+#include "fuzzuf/executor/afl_executor_interface.hpp"
 #include "fuzzuf/feedback/inplace_memory_feedback.hpp"
 #include "fuzzuf/feedback/exit_status_feedback.hpp"
 #include "fuzzuf/algorithms/afl/afl_option.hpp"
@@ -54,7 +54,7 @@ struct AFLStateTemplate {
     using Tag = typename Testcase::Tag;
 
     // FIXME: how to support other executors?
-    explicit AFLStateTemplate(std::shared_ptr<const AFLSetting> setting, std::shared_ptr<NativeLinuxExecutor> executor);
+    explicit AFLStateTemplate(std::shared_ptr<const AFLSetting> setting, std::shared_ptr<executor::AFLExecutorInterface> executor);
     virtual ~AFLStateTemplate();
 
     AFLStateTemplate( const AFLStateTemplate& ) = delete;
@@ -129,7 +129,7 @@ struct AFLStateTemplate {
     void SetShouldConstructAutoDict(bool v);
 
     std::shared_ptr<const AFLSetting> setting;
-    std::shared_ptr<NativeLinuxExecutor> executor;
+    std::shared_ptr<executor::AFLExecutorInterface> executor;
     ExecInputSet input_set;
 
     // TODO: what if this product works on environments other than *NIX?

--- a/include/fuzzuf/algorithms/afl/templates/afl_state.hpp
+++ b/include/fuzzuf/algorithms/afl/templates/afl_state.hpp
@@ -27,7 +27,7 @@
 #include "fuzzuf/utils/filesystem.hpp"
 #include "fuzzuf/exec_input/exec_input.hpp"
 #include "fuzzuf/exec_input/exec_input_set.hpp"
-#include "fuzzuf/executor/native_linux_executor.hpp"
+#include "fuzzuf/executor/afl_executor_interface.hpp"
 #include "fuzzuf/feedback/inplace_memory_feedback.hpp"
 #include "fuzzuf/feedback/exit_status_feedback.hpp"
 #include "fuzzuf/algorithms/afl/afl_option.hpp"
@@ -43,7 +43,7 @@ namespace fuzzuf::algorithm::afl {
 template<class Testcase>
 AFLStateTemplate<Testcase>::AFLStateTemplate(
     std::shared_ptr<const AFLSetting> setting,
-    std::shared_ptr<NativeLinuxExecutor> executor
+    std::shared_ptr<executor::AFLExecutorInterface> executor
 )
     : setting( setting ),
       executor( executor ),

--- a/include/fuzzuf/algorithms/aflfast/aflfast_state.hpp
+++ b/include/fuzzuf/algorithms/aflfast/aflfast_state.hpp
@@ -28,7 +28,7 @@ namespace fuzzuf::algorithm::aflfast {
 struct AFLFastState : public afl::AFLStateTemplate<AFLFastTestcase> {
     explicit AFLFastState(
         std::shared_ptr<const AFLFastSetting> setting,
-        std::shared_ptr<NativeLinuxExecutor> executor
+        std::shared_ptr<executor::AFLExecutorInterface> executor
     );
 
     std::shared_ptr<AFLFastTestcase> AddToQueue(

--- a/include/fuzzuf/algorithms/die/die_state.hpp
+++ b/include/fuzzuf/algorithms/die/die_state.hpp
@@ -35,7 +35,7 @@ namespace fuzzuf::algorithm::die {
 struct DIEState : public afl::AFLStateTemplate<DIETestcase> {
   explicit DIEState(
     std::shared_ptr<const DIESetting> setting,
-    std::shared_ptr<NativeLinuxExecutor> executor
+    std::shared_ptr<executor::AFLExecutorInterface> executor
   ) : AFLStateTemplate<DIETestcase>(setting, executor),
       setting(setting) {};
 

--- a/include/fuzzuf/algorithms/ijon/ijon_state.hpp
+++ b/include/fuzzuf/algorithms/ijon/ijon_state.hpp
@@ -24,7 +24,7 @@
 
 #include "fuzzuf/utils/filesystem.hpp"
 #include "fuzzuf/exec_input/exec_input_set.hpp"
-#include "fuzzuf/executor/native_linux_executor.hpp"
+#include "fuzzuf/executor/afl_executor_interface.hpp"
 #include "fuzzuf/algorithms/afl/afl_state.hpp"
 #include "fuzzuf/algorithms/ijon/ijon_option.hpp"
 #include "fuzzuf/algorithms/ijon/ijon_testcase.hpp"
@@ -38,7 +38,7 @@ namespace fuzzuf::algorithm::ijon {
  * The lifetime for an instance of this class must be longer than that of HierarFlow.
  */
 struct IJONState : public afl::AFLStateTemplate<IJONTestcase> {
-    explicit IJONState(std::shared_ptr<const afl::AFLSetting> setting, std::shared_ptr<NativeLinuxExecutor> executor);
+    explicit IJONState(std::shared_ptr<const afl::AFLSetting> setting, std::shared_ptr<executor::AFLExecutorInterface> executor);
     ~IJONState();
 
     IJONState( const IJONState& ) = delete;

--- a/include/fuzzuf/algorithms/libfuzzer/config.hpp
+++ b/include/fuzzuf/algorithms/libfuzzer/config.hpp
@@ -22,7 +22,7 @@
 #ifndef FUZZUF_INCLUDE_ALGORITHM_LIBFUZZER_CONFIG_HPP
 #define FUZZUF_INCLUDE_ALGORITHM_LIBFUZZER_CONFIG_HPP
 
-#include "fuzzuf/executor/native_linux_executor.hpp"
+#include "fuzzuf/executor/libfuzzer_executor_interface.hpp"
 #include "fuzzuf/utils/filesystem.hpp"
 #include "fuzzuf/utils/setter.hpp"
 #include <vector>

--- a/include/fuzzuf/algorithms/libfuzzer/create.hpp
+++ b/include/fuzzuf/algorithms/libfuzzer/create.hpp
@@ -119,19 +119,21 @@ auto createExecuteAndFeedback(const fs::path &target_path,
                               bool persistent, bool strict_match,
                               const Sink &sink) {
   namespace hf = fuzzuf::hierarflow;
+  using fuzzuf::executor::LibFuzzerExecutorInterface;
 
   const auto output_file_path = create_info.output_dir / "result";
   const auto path_to_write_seed = create_info.output_dir / "cur_input";
 
   auto create_coverage = hf::CreateNode<Clear<F, decltype(Ord::coverage)>>();
 
-  std::unique_ptr<NativeLinuxExecutor> executor_(new NativeLinuxExecutor(
+  std::shared_ptr<NativeLinuxExecutor> nle_(new NativeLinuxExecutor(
       {target_path.string(), output_file_path.string()},
       create_info.exec_timelimit_ms, create_info.exec_memlimit,
       create_info.forksrv, path_to_write_seed, create_info.afl_shm_size,
       create_info.bb_shm_size));
+  auto executor_ = std::make_unique<LibFuzzerExecutorInterface>(std::move(nle_));
   auto execute_ =
-      hf::CreateNode<standard_order::Execute<F, NativeLinuxExecutor, Ord>>(
+      hf::CreateNode<standard_order::Execute<F, LibFuzzerExecutorInterface, Ord>>(
           std::move(executor_), create_info.use_afl_coverage);
 
   auto collect_features =

--- a/include/fuzzuf/algorithms/nautilus/fuzzer/state.hpp
+++ b/include/fuzzuf/algorithms/nautilus/fuzzer/state.hpp
@@ -36,7 +36,7 @@
 #include "fuzzuf/algorithms/nautilus/grammartec/context.hpp"
 #include "fuzzuf/algorithms/nautilus/grammartec/mutator.hpp"
 #include "fuzzuf/algorithms/nautilus/grammartec/tree.hpp"
-#include "fuzzuf/executor/native_linux_executor.hpp"
+#include "fuzzuf/executor/afl_executor_interface.hpp"
 
 
 namespace fuzzuf::algorithm::nautilus::fuzzer {
@@ -51,7 +51,7 @@ enum ExecutionReason {
 struct NautilusState {
   explicit NautilusState(
     std::shared_ptr<const NautilusSetting> setting,
-    std::shared_ptr<NativeLinuxExecutor> executor
+    std::shared_ptr<executor::AFLExecutorInterface> executor
   );
 
   bool RunOnWithDedup(const TreeLike& tree,
@@ -81,7 +81,7 @@ struct NautilusState {
                                  size_t end_index);
 
   std::shared_ptr<const NautilusSetting> setting;
-  std::shared_ptr<NativeLinuxExecutor> executor;
+  std::shared_ptr<executor::AFLExecutorInterface> executor;
 
   /* Local state */
   Context ctx;

--- a/include/fuzzuf/cli/fuzzer/afl/build_afl_fuzzer_from_args.hpp
+++ b/include/fuzzuf/cli/fuzzer/afl/build_afl_fuzzer_from_args.hpp
@@ -55,7 +55,7 @@ static void usage(po::options_description &desc) {
 }
 
 // Used only for CLI
-template <class TFuzzer, class TAFLFuzzer>
+template <class TFuzzer, class TAFLFuzzer, class TExecutor>
 std::unique_ptr<TFuzzer> BuildAFLFuzzerFromArgs(
     FuzzerArgs &fuzzer_args, 
     GlobalFuzzerOptions &global_options
@@ -157,9 +157,7 @@ std::unique_ptr<TFuzzer> BuildAFLFuzzerFromArgs(
     using fuzzuf::algorithm::afl::option::GetMapSize;
 
     // Create NativeLinuxExecutor
-    // TODO: support more types of executors
-
-    auto executor = std::make_shared<NativeLinuxExecutor>(
+    auto nle = std::make_shared<NativeLinuxExecutor>(
                         setting->argv,
                         setting->exec_timelimit_ms,
                         setting->exec_memlimit,
@@ -168,6 +166,9 @@ std::unique_ptr<TFuzzer> BuildAFLFuzzerFromArgs(
                         GetMapSize<AFLTag>(), // afl_shm_size
                                            0  //  bb_shm_size
                     );
+
+    // TODO: support more types of executors
+    auto executor = std::make_shared<TExecutor>(std::move(nle));
 
     // Create AFLState
     using fuzzuf::algorithm::afl::AFLState;

--- a/include/fuzzuf/cli/fuzzer/aflfast/build_aflfast_fuzzer_from_args.hpp
+++ b/include/fuzzuf/cli/fuzzer/aflfast/build_aflfast_fuzzer_from_args.hpp
@@ -54,7 +54,7 @@ static void usage(po::options_description &desc) {
 
 
 // Used only for CLI
-template <class TFuzzer, class TAFLFuzzer>
+template <class TFuzzer, class TAFLFuzzer, class TExecutor>
 std::unique_ptr<TFuzzer> BuildAFLFastFuzzerFromArgs(
     FuzzerArgs &fuzzer_args, 
     GlobalFuzzerOptions &global_options
@@ -156,9 +156,7 @@ std::unique_ptr<TFuzzer> BuildAFLFastFuzzerFromArgs(
     using fuzzuf::algorithm::afl::option::GetMapSize;
 
     // Create NativeLinuxExecutor
-    // TODO: support more types of executors
-
-    auto executor = std::make_shared<NativeLinuxExecutor>(
+    auto nle = std::make_shared<NativeLinuxExecutor>(
                         setting->argv,
                         setting->exec_timelimit_ms,
                         setting->exec_memlimit,
@@ -167,6 +165,9 @@ std::unique_ptr<TFuzzer> BuildAFLFastFuzzerFromArgs(
                         GetMapSize<AFLFastTag>(), // afl_shm_size
                                            0      //  bb_shm_size
                     );
+
+    // TODO: support more types of executors
+    auto executor = std::make_shared<TExecutor>(std::move(nle));
 
     // Create AFLFastState
     using fuzzuf::algorithm::aflfast::AFLFastState;

--- a/include/fuzzuf/cli/fuzzer/die/build_die_fuzzer_from_args.hpp
+++ b/include/fuzzuf/cli/fuzzer/die/build_die_fuzzer_from_args.hpp
@@ -71,7 +71,7 @@ struct DIEOptions {
  * @param (fuzzer_args) Arguments passed to DIE
  * @param (global_options) Global options
  */
-template <class TFuzzer, class TDIEFuzzer>
+template <class TFuzzer, class TDIEFuzzer, class TExecutor>
 std::unique_ptr<TFuzzer> BuildDIEFuzzerFromArgs(FuzzerArgs &fuzzer_args,
                                                 GlobalFuzzerOptions &global_options) {
   po::positional_options_description pargs_desc;
@@ -184,7 +184,7 @@ std::unique_ptr<TFuzzer> BuildDIEFuzzerFromArgs(FuzzerArgs &fuzzer_args,
   using fuzzuf::algorithm::afl::option::GetMapSize;
 
   /* Create NativeLinuxExecutor */
-  auto executor = std::make_shared<NativeLinuxExecutor>(
+  auto nle = std::make_shared<NativeLinuxExecutor>(
     setting->argv,
     setting->exec_timelimit_ms,
     setting->exec_memlimit,
@@ -193,6 +193,8 @@ std::unique_ptr<TFuzzer> BuildDIEFuzzerFromArgs(FuzzerArgs &fuzzer_args,
     GetMapSize<DIETag>(), // afl_shm_size
     0 // bb_shm_size
   );
+
+  auto executor = std::make_shared<TExecutor>(std::move(nle));
 
   using fuzzuf::algorithm::die::DIEState;
 

--- a/include/fuzzuf/cli/fuzzer/ijon/build_ijon_fuzzer_from_args.hpp
+++ b/include/fuzzuf/cli/fuzzer/ijon/build_ijon_fuzzer_from_args.hpp
@@ -52,7 +52,7 @@ static void usage(po::options_description &desc) {
 }
 
 // Used only for CLI
-template <class TFuzzer, class TIJONFuzzer>
+template <class TFuzzer, class TIJONFuzzer, class TExecutor>
 std::unique_ptr<TFuzzer> BuildIJONFuzzerFromArgs(
     FuzzerArgs &fuzzer_args, 
     GlobalFuzzerOptions &global_options
@@ -132,7 +132,7 @@ std::unique_ptr<TFuzzer> BuildIJONFuzzerFromArgs(
     // TODO: support more types of executors
 
     using algorithm::ijon::SharedData;
-    auto executor = std::make_shared<NativeLinuxExecutor>(
+    auto nle = std::make_shared<NativeLinuxExecutor>(
                         setting->argv,
                         setting->exec_timelimit_ms,
                         setting->exec_memlimit,
@@ -141,6 +141,8 @@ std::unique_ptr<TFuzzer> BuildIJONFuzzerFromArgs(
                         sizeof(SharedData), // afl_shm_size
                                          0  //  bb_shm_size
                     );
+
+    auto executor = std::make_shared<TExecutor>(std::move(nle));
 
     // Create IJONState
     using fuzzuf::algorithm::ijon::IJONState;

--- a/include/fuzzuf/cli/fuzzer/libfuzzer/build_libfuzzer_from_args.hpp
+++ b/include/fuzzuf/cli/fuzzer/libfuzzer/build_libfuzzer_from_args.hpp
@@ -26,7 +26,7 @@
 namespace po = boost::program_options;
 
 // Used only for CLI
-template <class TFuzzer, class TLibFuzzer>
+template <class TFuzzer, class TLibFuzzer, class TExecutor>
 std::unique_ptr<TFuzzer> BuildLibFuzzerFromArgs(
     FuzzerArgs &fuzzer_args, 
     GlobalFuzzerOptions &global_options

--- a/include/fuzzuf/cli/fuzzer/nautilus/build_nautilus_fuzzer_from_args.hpp
+++ b/include/fuzzuf/cli/fuzzer/nautilus/build_nautilus_fuzzer_from_args.hpp
@@ -55,7 +55,7 @@ using fuzzuf::algorithm::nautilus::fuzzer::NautilusFuzzer;
  * @param (fuzzer_args) Arguments passed to Nautilus
  * @param (global_options) Global options
  */
-template <class TFuzzer, class TNautilusFuzzer>
+template <class TFuzzer, class TNautilusFuzzer, class TExecutor>
 std::unique_ptr<TFuzzer> BuildNautilusFuzzerFromArgs(
   FuzzerArgs &fuzzer_args,
   GlobalFuzzerOptions &global_options
@@ -191,7 +191,7 @@ std::unique_ptr<TFuzzer> BuildNautilusFuzzerFromArgs(
   using fuzzuf::algorithm::afl::option::GetMapSize;
 
   /* Create NativeLinuxExecutor */
-  auto executor = std::make_shared<NativeLinuxExecutor>(
+  auto nle = std::make_shared<NativeLinuxExecutor>(
     put.Args(),
     setting->exec_timeout_ms,
     setting->exec_memlimit,
@@ -201,6 +201,8 @@ std::unique_ptr<TFuzzer> BuildNautilusFuzzerFromArgs(
     0,                    // bb_shm_size is not used
     setting->cpuid_to_bind
   );
+
+  auto executor = std::make_shared<TExecutor>(std::move(nle));
 
   using fuzzuf::algorithm::nautilus::fuzzer::NautilusState;
   using fuzzuf::algorithm::nautilus::grammartec::ChunkStore;

--- a/include/fuzzuf/cli/fuzzer/nezha/build_nezha_fuzzer_from_args.hpp
+++ b/include/fuzzuf/cli/fuzzer/nezha/build_nezha_fuzzer_from_args.hpp
@@ -23,7 +23,7 @@
 #include "fuzzuf/exceptions.hpp"
 
 // Used only for CLI
-template <class TFuzzer, class TNezhaFuzzer>
+template <class TFuzzer, class TNezhaFuzzer, class TExecutor>
 std::unique_ptr<TFuzzer> BuildNezhaFuzzerFromArgs(
     FuzzerArgs &fuzzer_args, 
     GlobalFuzzerOptions &global_options

--- a/include/fuzzuf/executor/afl_executor_interface.hpp
+++ b/include/fuzzuf/executor/afl_executor_interface.hpp
@@ -1,0 +1,133 @@
+/*
+ * fuzzuf
+ * Copyright (C) 2022 Ricerca Security
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see http://www.gnu.org/licenses/.
+ */
+
+/**
+ * @file afl_executor_interface.hpp
+ * @author Ricerca Security <fuzzuf-dev@ricsec.co.jp>
+ */
+
+#ifndef FUZZUF_INCLUDE_EXECUTOR_AFL_EXECUTOR_INTERFACE_HPP
+#define FUZZUF_INCLUDE_EXECUTOR_AFL_EXECUTOR_INTERFACE_HPP
+
+#include <memory>
+
+#include "fuzzuf/feedback/exit_status_feedback.hpp"
+#include "fuzzuf/feedback/inplace_memory_feedback.hpp"
+#include "fuzzuf/utils/common.hpp"
+
+namespace fuzzuf::executor {
+
+/**
+ * @class AFLExecutorInterface
+ * @brief Represents minimal requirements for an AFL-capable executor.
+ * 
+ * @details The executor for AFL must have the methods declared in this class.
+ * This class is to perform type erasure for the executor class to abstract
+ * the executor on the algortihms. We found that the boost's type_erasure does
+ * not meet our needs, so we implemented our own type erasure.
+ * 
+ * @note An AFL-capable executor must have the following functions:
+ * - void Run(const u8 *buf, u32 len, u32 timeout_ms)
+ * - InplaceMemoryFeedback GetAFLFeedback()
+ * - ExitStatusFeedback GetExitStatusFeedback()
+ * - void ReceiveStopSignal()
+ */
+class AFLExecutorInterface
+{
+public:
+  template<class T> AFLExecutorInterface(const std::shared_ptr<T>& executor)
+  : _container(new DynContainerDerived<T>(executor))
+  {}
+
+  template<class T> AFLExecutorInterface(std::shared_ptr<T>&& executor) noexcept
+  : _container(new DynContainerDerived<T>(std::move(executor)))
+  {}
+
+  AFLExecutorInterface(const AFLExecutorInterface&) = delete;
+  AFLExecutorInterface(AFLExecutorInterface&&) = delete;
+  AFLExecutorInterface &operator=(const AFLExecutorInterface&) = delete;
+  AFLExecutorInterface &operator=(AFLExecutorInterface&&) = delete;
+  AFLExecutorInterface() = delete;
+
+  /// @brief Executes the executor with given inputs.
+  /// @param buf A pointer to the fuzzing input.
+  /// @param len Length of the fuzzing input.
+  /// @param timeout_ms Execution timeout in milliseconds.
+  void Run(const u8 *buf, u32 len, u32 timeout_ms=0) {
+    _container->Run(buf, len, timeout_ms);
+  }
+
+  /// @brief Gets AFL-compatible hashed edge coverage bitmap.
+  /// @return AFL-compatible hashed edge coverage bitmap.
+  InplaceMemoryFeedback GetAFLFeedback() {
+    return _container->GetAFLFeedback();
+  }
+
+  /// @brief Gets an exit status of last execution.
+  /// @return An exit status of last execution.
+  ExitStatusFeedback GetExitStatusFeedback() {
+    return _container->GetExitStatusFeedback();
+  }
+
+  /// @brief A callback function called when the fuzzer receives a stop signal.
+  void ReceiveStopSignal() {
+    _container->ReceiveStopSignal();
+  }
+
+private:
+  class DynContainerBase {
+  public:
+    virtual ~DynContainerBase() {}
+    virtual void Run(const u8 *buf, u32 len, u32 timeout_ms=0) = 0;
+    virtual InplaceMemoryFeedback GetAFLFeedback() = 0;
+    virtual ExitStatusFeedback GetExitStatusFeedback() = 0;
+    virtual void ReceiveStopSignal() = 0;
+  };
+
+  template<class T>
+  class DynContainerDerived : public DynContainerBase {
+  public:
+    DynContainerDerived(std::shared_ptr<T> const &executor) : _executor(executor) {}
+    DynContainerDerived(std::shared_ptr<T> &&executor) noexcept : _executor(std::move(executor)) {}
+
+    void Run(const u8 *buf, u32 len, u32 timeout_ms=0) {
+      _executor->Run(buf, len, timeout_ms);
+    }
+
+    InplaceMemoryFeedback GetAFLFeedback() {
+      return _executor->GetAFLFeedback();
+    }
+
+    ExitStatusFeedback GetExitStatusFeedback() {
+      return _executor->GetExitStatusFeedback();
+    }
+
+    void ReceiveStopSignal() {
+      return _executor->ReceiveStopSignal();
+    }
+
+  private:
+    std::shared_ptr<T> _executor;
+  };
+
+  std::unique_ptr<DynContainerBase> _container;
+};
+
+} // namespace fuzzuf::executor
+
+#endif // FUZZUF_INCLUDE_EXECUTOR_AFL_EXECUTOR_INTERFACE_HPP

--- a/include/fuzzuf/executor/libfuzzer_executor_interface.hpp
+++ b/include/fuzzuf/executor/libfuzzer_executor_interface.hpp
@@ -1,0 +1,159 @@
+/*
+ * fuzzuf
+ * Copyright (C) 2022 Ricerca Security
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see http://www.gnu.org/licenses/.
+ */
+
+/**
+ * @file libfuzzer_executor_interface.hpp
+ * @author Ricerca Security <fuzzuf-dev@ricsec.co.jp>
+ */
+
+#ifndef FUZZUF_INCLUDE_EXECUTOR_LIBFUZZER_EXECUTOR_INTERFACE_HPP
+#define FUZZUF_INCLUDE_EXECUTOR_LIBFUZZER_EXECUTOR_INTERFACE_HPP
+
+#include <memory>
+
+#include "fuzzuf/executor/executor.hpp"
+#include "fuzzuf/feedback/exit_status_feedback.hpp"
+#include "fuzzuf/feedback/inplace_memory_feedback.hpp"
+#include "fuzzuf/utils/common.hpp"
+
+namespace fuzzuf::executor {
+
+/**
+ * @class LibFuzzerExecutorInterface
+ * @brief Represents minimal requirements for a libFuzzer-capable executor.
+ * 
+ * @details The executor for libFuzzer must have the methods declared in this
+ * class. This class is to perform type erasure for the executor class to
+ * abstract the executor on the algortihms. We found that the boost's
+ * type_erasure does not meet our needs, so we implemented our own type erasure.
+ *
+ * @note A libFuzzer-capable executor must have the following functions.
+ * - void Run(const u8 *buf, u32 len, u32 timeout_ms)
+ * - InplaceMemoryFeedback GetAFLFeedback()
+ * - InplaceMemoryFeedback GetBBFeedback()
+ * - ExitStatusFeedback GetExitStatusFeedback()
+ * - fuzzuf::executor::output_t MoveStdOut()
+ * - fuzzuf::executor::output_t MoveStdErr()
+ */
+class LibFuzzerExecutorInterface
+{
+public:
+  template<class T> LibFuzzerExecutorInterface(const std::shared_ptr<T>& executor)
+  : _container(new DynContainerDerived<T>(executor))
+  {}
+
+  template<class T> LibFuzzerExecutorInterface(std::shared_ptr<T>&& executor) noexcept
+  : _container(new DynContainerDerived<T>(std::move(executor)))
+  {}
+
+  LibFuzzerExecutorInterface(const LibFuzzerExecutorInterface&) = delete;
+  LibFuzzerExecutorInterface(LibFuzzerExecutorInterface&&) = delete;
+  LibFuzzerExecutorInterface &operator=(const LibFuzzerExecutorInterface&) = delete;
+  LibFuzzerExecutorInterface &operator=(LibFuzzerExecutorInterface&&) = delete;
+  LibFuzzerExecutorInterface() = delete;
+
+ /// @brief Executes the executor with given inputs.
+ /// @param buf A pointer to the fuzzing input.
+ /// @param len Length of the fuzzing input.
+ /// @param timeout_ms Execution timeout in milliseconds.
+  void Run(const u8 *buf, u32 len, u32 timeout_ms=0) {
+    _container->Run(buf, len, timeout_ms);
+  }
+
+  /// @brief Gets AFL-compatible hashed edge coverage bitmap.
+  /// @return AFL-compatible hashed edge coverage bitmap.
+  InplaceMemoryFeedback GetAFLFeedback() {
+    return _container->GetAFLFeedback();
+  }
+
+  /// @brief Gets fuzzuf basic block coverage bitmap.
+  /// @return fuzzuf basic block coverage bitmap.
+  InplaceMemoryFeedback GetBBFeedback() {
+    return _container->GetBBFeedback();
+  }
+
+  /// @brief Gets an exit status of last execution.
+  /// @return An exit status of last execution.
+  ExitStatusFeedback GetExitStatusFeedback() {
+    return _container->GetExitStatusFeedback();
+  }
+
+  /// @brief Moves captured stdout output during the execution.
+  /// @return Captured stdout output during the execution.
+  fuzzuf::executor::output_t MoveStdOut() {
+    return _container->MoveStdOut();
+  }
+
+  /// @brief Moves captured stderr output during the execution.
+  /// @return Captured stderr output during the execution.
+  fuzzuf::executor::output_t MoveStdErr() {
+    return _container->MoveStdErr();
+  }
+
+private:
+  class DynContainerBase {
+  public:
+    virtual ~DynContainerBase() {}
+    virtual void Run(const u8 *buf, u32 len, u32 timeout_ms=0) = 0;
+    virtual InplaceMemoryFeedback GetAFLFeedback() = 0;
+    virtual InplaceMemoryFeedback GetBBFeedback() = 0;
+    virtual ExitStatusFeedback GetExitStatusFeedback() = 0;
+    virtual fuzzuf::executor::output_t MoveStdOut() = 0;
+    virtual fuzzuf::executor::output_t MoveStdErr() = 0;
+  };
+
+  template<class T>
+  class DynContainerDerived : public DynContainerBase {
+  public:
+    DynContainerDerived(std::shared_ptr<T> const &executor) : _executor(executor) {}
+    DynContainerDerived(std::shared_ptr<T> &&executor) noexcept : _executor(std::move(executor)) {}
+
+    void Run(const u8 *buf, u32 len, u32 timeout_ms=0) {
+      _executor->Run(buf, len, timeout_ms);
+    }
+
+    InplaceMemoryFeedback GetAFLFeedback() {
+      return _executor->GetAFLFeedback();
+    }
+
+    InplaceMemoryFeedback GetBBFeedback() {
+      return _executor->GetBBFeedback();
+    }
+
+    ExitStatusFeedback GetExitStatusFeedback() {
+      return _executor->GetExitStatusFeedback();
+    }
+
+    fuzzuf::executor::output_t MoveStdOut() {
+      return _executor->MoveStdOut();
+    }
+
+    fuzzuf::executor::output_t MoveStdErr() {
+      return _executor->MoveStdErr();
+    }
+
+  private:
+    std::shared_ptr<T> _executor;
+  };
+
+  std::unique_ptr<DynContainerBase> _container;
+};
+
+} // namespace fuzzuf::executor
+
+#endif // FUZZUF_INCLUDE_EXECUTOR_LIBFUZZER_EXECUTOR_INTERFACE_HPP

--- a/test/algorithms/afl/loop.cpp
+++ b/test/algorithms/afl/loop.cpp
@@ -23,6 +23,7 @@
 #include <random>
 
 #include "fuzzuf/algorithms/afl/afl_fuzzer.hpp"
+#include "fuzzuf/executor/native_linux_executor.hpp"
 #include "fuzzuf/utils/filesystem.hpp"
 #include "fuzzuf/utils/workspace.hpp"
 #include "move_to_program_location.hpp"
@@ -56,6 +57,7 @@ static void AFLLoop(bool forksrv) {
   // FIXME: we can use BuildAFLFuzzerFromArgs after it supports forksrv as an
   // option
   using namespace fuzzuf::algorithm::afl;
+  using fuzzuf::executor::AFLExecutorInterface;
   using option::AFLTag;
 
   std::shared_ptr<AFLSetting> setting(new AFLSetting(
@@ -70,12 +72,14 @@ static void AFLLoop(bool forksrv) {
   SetupDirs(setting->out_dir.string());
 
   // Create NativeLinuxExecutor
-  auto executor = std::make_shared<NativeLinuxExecutor>(
+  auto nle = std::make_shared<NativeLinuxExecutor>(
       setting->argv, setting->exec_timelimit_ms, setting->exec_memlimit,
       setting->forksrv, setting->out_dir / option::GetDefaultOutfile<AFLTag>(),
       option::GetMapSize<AFLTag>(), // afl_shm_size
       0                             // bb_shm_size
       );
+
+  auto executor = std::make_shared<AFLExecutorInterface>(std::move(nle));
 
   // Create AFLState
   auto state = std::make_unique<AFLState>(setting, executor);

--- a/test/algorithms/die/loop.cpp
+++ b/test/algorithms/die/loop.cpp
@@ -30,6 +30,7 @@
 #include "fuzzuf/algorithms/die/die_fuzzer.hpp"
 #include "fuzzuf/algorithms/die/die_option.hpp"
 #include "fuzzuf/algorithms/die/die_setting.hpp"
+#include "fuzzuf/executor/native_linux_executor.hpp"
 #include "fuzzuf/utils/common.hpp"
 #include "fuzzuf/utils/filesystem.hpp"
 #include "fuzzuf/utils/workspace.hpp"
@@ -66,6 +67,7 @@ BOOST_AUTO_TEST_CASE(DIELoop) {
   fs::path output_dir = root_dir / "output";
 
   using namespace fuzzuf::algorithm::afl;
+  using fuzzuf::executor::AFLExecutorInterface;
   using fuzzuf::algorithm::die::DIEFuzzer;
   using fuzzuf::algorithm::die::DIESetting;
   using fuzzuf::algorithm::die::DIEState;
@@ -97,7 +99,7 @@ BOOST_AUTO_TEST_CASE(DIELoop) {
   SetupDirs(setting->out_dir.string());
 
   // Create NativeLinuxExecutor
-  auto executor = std::make_shared<NativeLinuxExecutor>(
+  auto nle = std::make_shared<NativeLinuxExecutor>(
     setting->argv,
     setting->exec_timelimit_ms,
     setting->exec_memlimit,
@@ -106,6 +108,8 @@ BOOST_AUTO_TEST_CASE(DIELoop) {
     option::GetMapSize<DIETag>(), // afl_shm_size
     0                             // bb_shm_size
   );
+
+  auto executor = std::make_shared<AFLExecutorInterface>(std::move(nle));
 
   // Create DIEState
   auto state = std::make_unique<DIEState>(setting, executor);

--- a/test/algorithms/libfuzzer/execute2.cpp
+++ b/test/algorithms/libfuzzer/execute2.cpp
@@ -25,6 +25,8 @@
 #include "fuzzuf/algorithms/libfuzzer/mutation.hpp"
 #include "fuzzuf/algorithms/libfuzzer/select_seed.hpp"
 #include "fuzzuf/algorithms/libfuzzer/test_utils.hpp"
+#include "fuzzuf/executor/native_linux_executor.hpp"
+#include "fuzzuf/executor/libfuzzer_executor_interface.hpp"
 #include "fuzzuf/hierarflow/hierarflow_intermediates.hpp"
 #include "fuzzuf/utils/filesystem.hpp"
 #include "fuzzuf/utils/map_file.hpp"
@@ -64,6 +66,7 @@ BOOST_AUTO_TEST_CASE(HierarFlowExecute) {
 
   namespace lf = fuzzuf::algorithm::libfuzzer;
   namespace hf = fuzzuf::hierarflow;
+  using fuzzuf::executor::LibFuzzerExecutorInterface;
 
   BOOST_TEST_CHECKPOINT("before init state");
 
@@ -124,11 +127,12 @@ BOOST_AUTO_TEST_CASE(HierarFlowExecute) {
   {
     const auto output_file_path = create_info.output_dir / "result";
     const auto path_to_write_seed = create_info.output_dir / "cur_input";
-    std::unique_ptr<NativeLinuxExecutor> executor(new NativeLinuxExecutor(
+    std::shared_ptr<NativeLinuxExecutor> nle(new NativeLinuxExecutor(
         {FUZZUF_FUZZTOYS_DIR "/fuzz_toys-brainf_ck", output_file_path.string()},
         create_info.exec_timelimit_ms, create_info.exec_memlimit,
         create_info.forksrv, path_to_write_seed, create_info.afl_shm_size,
         create_info.bb_shm_size));
+    auto executor = std::make_unique<LibFuzzerExecutorInterface>(std::move(nle));
     std::size_t solution_count = 0u;
     for (const auto &filename :
          fs::directory_iterator{create_info.output_dir}) {

--- a/test/algorithms/libfuzzer/feature.cpp
+++ b/test/algorithms/libfuzzer/feature.cpp
@@ -55,6 +55,7 @@ BOOST_AUTO_TEST_CASE(Feature) {
   namespace hf = fuzzuf::hierarflow;                                           \
   namespace ut = fuzzuf::utils;                                                \
   namespace sp = ut::struct_path;
+  using fuzzuf::executor::LibFuzzerExecutorInterface;
 
 // Check if lf::executor::Execute can retrive standard output
 BOOST_AUTO_TEST_CASE(ExecuteOutput) {
@@ -62,9 +63,10 @@ BOOST_AUTO_TEST_CASE(ExecuteOutput) {
   FUZZUF_TEST_ALGORITHM_LIBFUZZER_FEATURE_PREPARE_OUTDIR
   // NOLINTEND(cppcoreguidelines-pro-type-cstyle-cast,cppcoreguidelines-pro-type-member-init,cppcoreguidelines-special-member-functions,hicpp-explicit-conversions)
 
-  std::unique_ptr<NativeLinuxExecutor> executor(new NativeLinuxExecutor(
+  std::shared_ptr<NativeLinuxExecutor> nle(new NativeLinuxExecutor(
       {fuzzuf::utils::which(fs::path("wc")).c_str(), "-c"}, 1000, 10000, false,
       path_to_write_seed, 65536, 65536, true));
+  auto executor = std::make_unique<LibFuzzerExecutorInterface>(std::move(nle));
 
   lf::InputInfo testcase;
   auto input = lf::test::getSeed1();
@@ -82,9 +84,10 @@ BOOST_AUTO_TEST_CASE(HierarFlowExecuteOutput) {
   FUZZUF_TEST_ALGORITHM_LIBFUZZER_FEATURE_PREPARE_OUTDIR
   // NOLINTEND(cppcoreguidelines-pro-type-cstyle-cast,cppcoreguidelines-pro-type-member-init,cppcoreguidelines-special-member-functions,hicpp-explicit-conversions)
 
-  std::unique_ptr<NativeLinuxExecutor> executor(new NativeLinuxExecutor(
+  std::shared_ptr<NativeLinuxExecutor> nle(new NativeLinuxExecutor(
       {fuzzuf::utils::which(fs::path("wc")).c_str(), "-c"}, 1000, 10000, false,
       path_to_write_seed, 65536, 65536, true));
+  auto executor = std::make_unique<LibFuzzerExecutorInterface>(std::move(nle));
 
   constexpr static auto output_loc = sp::root / sp::arg<1>;
   using Ord =
@@ -92,7 +95,7 @@ BOOST_AUTO_TEST_CASE(HierarFlowExecuteOutput) {
                lf::test::Order::coverage && lf::test::Order::exec_result);
   using WithOutput = bool(lf::test::Variables &, std::vector<std::uint8_t> &,
                           ut::DumpTracer &, ut::ElapsedTimeTracer &);
-  auto node = hf::CreateNode<lf::Execute<WithOutput, NativeLinuxExecutor, Ord>>(
+  auto node = hf::CreateNode<lf::Execute<WithOutput, LibFuzzerExecutorInterface, Ord>>(
       std::move(executor), true);
 
   lf::test::Variables variables;
@@ -114,9 +117,10 @@ BOOST_AUTO_TEST_CASE(ExecuteStatusSuccess) {
   FUZZUF_TEST_ALGORITHM_LIBFUZZER_FEATURE_PREPARE_OUTDIR
   // NOLINTEND(cppcoreguidelines-pro-type-cstyle-cast,cppcoreguidelines-pro-type-member-init,cppcoreguidelines-special-member-functions,hicpp-explicit-conversions)
 
-  std::unique_ptr<NativeLinuxExecutor> executor(new NativeLinuxExecutor(
+  std::shared_ptr<NativeLinuxExecutor> nle(new NativeLinuxExecutor(
       {TEST_BINARY_DIR "/executor/ok"}, 1000, 10000, false, path_to_write_seed,
       65536, 65536));
+  auto executor = std::make_unique<LibFuzzerExecutorInterface>(std::move(nle));
 
   lf::InputInfo testcase;
   auto input = lf::test::getSeed1();
@@ -132,12 +136,13 @@ BOOST_AUTO_TEST_CASE(HierarFlowExecuteStatusSuccess) {
   FUZZUF_TEST_ALGORITHM_LIBFUZZER_FEATURE_PREPARE_OUTDIR
   // NOLINTEND(cppcoreguidelines-pro-type-cstyle-cast,cppcoreguidelines-pro-type-member-init,cppcoreguidelines-special-member-functions,hicpp-explicit-conversions)
 
-  std::unique_ptr<NativeLinuxExecutor> executor(new NativeLinuxExecutor(
+  std::shared_ptr<NativeLinuxExecutor> nle(new NativeLinuxExecutor(
       {TEST_BINARY_DIR "/executor/ok"}, 1000, 10000, false, path_to_write_seed,
       65536, 65536));
+  auto executor = std::make_unique<LibFuzzerExecutorInterface>(std::move(nle));
 
   auto node = hf::CreateNode<lf::standard_order::Execute<
-      lf::test::Full, NativeLinuxExecutor, lf::test::Order>>(
+      lf::test::Full, LibFuzzerExecutorInterface, lf::test::Order>>(
       std::move(executor), true);
 
   lf::test::Variables variables;
@@ -157,9 +162,10 @@ BOOST_AUTO_TEST_CASE(ExecuteStatusAbort) {
   FUZZUF_TEST_ALGORITHM_LIBFUZZER_FEATURE_PREPARE_OUTDIR
   // NOLINTEND(cppcoreguidelines-pro-type-cstyle-cast,cppcoreguidelines-pro-type-member-init,cppcoreguidelines-special-member-functions,hicpp-explicit-conversions)
 
-  std::unique_ptr<NativeLinuxExecutor> executor(
+  std::shared_ptr<NativeLinuxExecutor> nle(
       new NativeLinuxExecutor({TEST_BINARY_DIR "/executor/abort"}, 1000, 10000,
                               false, path_to_write_seed, 65536, 65536));
+  auto executor = std::make_unique<LibFuzzerExecutorInterface>(std::move(nle));
 
   lf::InputInfo testcase;
   auto input = lf::test::getSeed1();
@@ -177,12 +183,13 @@ BOOST_AUTO_TEST_CASE(HierarFlowExecuteAbort) {
   FUZZUF_TEST_ALGORITHM_LIBFUZZER_FEATURE_PREPARE_OUTDIR
   // NOLINTEND(cppcoreguidelines-pro-type-cstyle-cast,cppcoreguidelines-pro-type-member-init,cppcoreguidelines-special-member-functions,hicpp-explicit-conversions)
 
-  std::unique_ptr<NativeLinuxExecutor> executor(
+  std::shared_ptr<NativeLinuxExecutor> nle(
       new NativeLinuxExecutor({TEST_BINARY_DIR "/executor/abort"}, 1000, 10000,
                               false, path_to_write_seed, 65536, 65536));
+  auto executor = std::make_unique<LibFuzzerExecutorInterface>(std::move(nle));
 
   auto node = hf::CreateNode<lf::standard_order::Execute<
-      lf::test::Full, NativeLinuxExecutor, lf::test::Order>>(
+      lf::test::Full, LibFuzzerExecutorInterface, lf::test::Order>>(
       std::move(executor), true);
 
   lf::test::Variables variables;
@@ -202,10 +209,11 @@ BOOST_AUTO_TEST_CASE(ExecuteCoverage) {
   FUZZUF_TEST_ALGORITHM_LIBFUZZER_FEATURE_PREPARE_OUTDIR
   // NOLINTEND(cppcoreguidelines-pro-type-cstyle-cast,cppcoreguidelines-pro-type-member-init,cppcoreguidelines-special-member-functions,hicpp-explicit-conversions)
 
-  std::unique_ptr<NativeLinuxExecutor> executor(
+  std::shared_ptr<NativeLinuxExecutor> nle(
       new NativeLinuxExecutor({FUZZUF_FUZZTOYS_DIR "/fuzz_toys-brainf_ck"},
                               1000, 10000, false, path_to_write_seed, 65536,
                               65536));
+  auto executor = std::make_unique<LibFuzzerExecutorInterface>(std::move(nle));
 
   lf::InputInfo testcase;
   std::vector<std::uint8_t> input{'+'};
@@ -223,13 +231,14 @@ BOOST_AUTO_TEST_CASE(HierarFlowExecuteCoverage) {
   FUZZUF_TEST_ALGORITHM_LIBFUZZER_FEATURE_PREPARE_OUTDIR
   // NOLINTEND(cppcoreguidelines-pro-type-cstyle-cast,cppcoreguidelines-pro-type-member-init,cppcoreguidelines-special-member-functions,hicpp-explicit-conversions)
 
-  std::unique_ptr<NativeLinuxExecutor> executor(
+  std::shared_ptr<NativeLinuxExecutor> nle(
       new NativeLinuxExecutor({FUZZUF_FUZZTOYS_DIR "/fuzz_toys-brainf_ck"},
                               1000, 10000, false, path_to_write_seed, 65536,
                               65536));
+  auto executor = std::make_unique<LibFuzzerExecutorInterface>(std::move(nle));
 
   auto node = hf::CreateNode<lf::standard_order::Execute<
-      lf::test::Full, NativeLinuxExecutor, lf::test::Order>>(
+      lf::test::Full, LibFuzzerExecutorInterface, lf::test::Order>>(
       std::move(executor), true);
 
   lf::test::Variables variables;

--- a/test/algorithms/libfuzzer/initialize.cpp
+++ b/test/algorithms/libfuzzer/initialize.cpp
@@ -60,12 +60,14 @@ BOOST_AUTO_TEST_CASE(Initialize) {
   BOOST_SCOPE_EXIT_END
   // NOLINTEND(cppcoreguidelines-pro-type-cstyle-cast,cppcoreguidelines-pro-type-member-init,cppcoreguidelines-special-member-functions,hicpp-explicit-conversions)
 
+  using fuzzuf::executor::LibFuzzerExecutorInterface;
   BOOST_TEST_CHECKPOINT("before init executor");
-  std::unique_ptr<NativeLinuxExecutor> executor(
+  std::shared_ptr<NativeLinuxExecutor> nle(
       new NativeLinuxExecutor({fuzzuf::utils::which(fs::path("tee")).c_str(),
                                output_file_path.native()},
                               1000, 10000, false, path_to_write_seed, 1000,
                               1000));
+  auto executor = std::make_unique<LibFuzzerExecutorInterface>(std::move(nle));
   BOOST_TEST_CHECKPOINT("after init executor");
 
   namespace lf = fuzzuf::algorithm::libfuzzer;
@@ -147,13 +149,16 @@ BOOST_AUTO_TEST_CASE(HierarFlowExecute) {
   BOOST_SCOPE_EXIT_END
   // NOLINTEND(cppcoreguidelines-pro-type-cstyle-cast,cppcoreguidelines-pro-type-member-init,cppcoreguidelines-special-member-functions,hicpp-explicit-conversions)
 
+  using fuzzuf::executor::LibFuzzerExecutorInterface;
+
   BOOST_TEST_CHECKPOINT("before int executor");
 
-  std::unique_ptr<NativeLinuxExecutor> executor(
+  std::shared_ptr<NativeLinuxExecutor> nle(
       new NativeLinuxExecutor({fuzzuf::utils::which(fs::path("tee")).c_str(),
                                output_file_path.native()},
                               1000, 10000, false, path_to_write_seed, 1000,
                               1000));
+  auto executor = std::make_unique<LibFuzzerExecutorInterface>(std::move(nle));
 
   BOOST_TEST_CHECKPOINT("after init executor");
 
@@ -184,7 +189,7 @@ BOOST_AUTO_TEST_CASE(HierarFlowExecute) {
   auto create_input_info = hf::CreateNode<
       lf::StaticAssign<lf::test::Full, decltype(Ord::exec_result)>>();
   auto execute = hf::CreateNode<
-      lf::standard_order::Execute<lf::test::Full, NativeLinuxExecutor, Ord>>(
+      lf::standard_order::Execute<lf::test::Full, LibFuzzerExecutorInterface, Ord>>(
       std::move(executor), true);
   auto collect_features = hf::CreateNode<
       lf::standard_order::CollectFeatures<lf::test::Full, Ord>>();

--- a/test/algorithms/nautilus/loop.cpp
+++ b/test/algorithms/nautilus/loop.cpp
@@ -97,9 +97,10 @@ static void NautilusLoop(bool forksrv, size_t iter) {
 
   using fuzzuf::algorithm::afl::option::GetDefaultOutfile;
   using fuzzuf::algorithm::afl::option::GetMapSize;
+  using fuzzuf::executor::AFLExecutorInterface;
 
   /* Create NativeLinuxExecutor */
-  auto executor = std::make_shared<NativeLinuxExecutor>(
+  auto nle = std::make_shared<NativeLinuxExecutor>(
     args,
     setting->exec_timeout_ms,
     setting->exec_memlimit,
@@ -109,6 +110,8 @@ static void NautilusLoop(bool forksrv, size_t iter) {
     0,                         // bb_shm_size
     setting->cpuid_to_bind
   );
+
+  auto executor = std::make_shared<AFLExecutorInterface>(std::move(nle));
 
   using fuzzuf::algorithm::nautilus::fuzzer::NautilusState;
   using fuzzuf::algorithm::nautilus::grammartec::ChunkStore;

--- a/test/algorithms/nezha/output_hash3.cpp
+++ b/test/algorithms/nezha/output_hash3.cpp
@@ -20,6 +20,7 @@
 #include "fuzzuf/algorithms/nezha/cli_compat/fuzzer.hpp"
 #include "fuzzuf/algorithms/libfuzzer/executor/execute.hpp"
 #include "fuzzuf/cli/global_fuzzer_options.hpp"
+#include "fuzzuf/executor/native_linux_executor.hpp"
 #include "fuzzuf/utils/filesystem.hpp"
 #include "fuzzuf/utils/map_file.hpp"
 #include "fuzzuf/utils/sha1.hpp"
@@ -60,6 +61,7 @@ BOOST_AUTO_TEST_CASE(HierarFlowExecute) {
 
   namespace lf = fuzzuf::algorithm::libfuzzer;
   namespace ne = fuzzuf::algorithm::nezha;
+  using fuzzuf::executor::LibFuzzerExecutorInterface;
 
   BOOST_TEST_CHECKPOINT("before init state");
 
@@ -109,16 +111,18 @@ BOOST_AUTO_TEST_CASE(HierarFlowExecute) {
     namespace tt = boost::test_tools;
     const auto output_file_path = create_info.output_dir / "result";
     const auto path_to_write_seed = create_info.output_dir / "cur_input";
-    std::unique_ptr<NativeLinuxExecutor> executor1(new NativeLinuxExecutor(
+    std::shared_ptr<NativeLinuxExecutor> nle1(new NativeLinuxExecutor(
         {FUZZUF_FUZZTOYS_DIR "/fuzz_toys-csv_small", output_file_path.string()},
         create_info.exec_timelimit_ms, create_info.exec_memlimit,
         create_info.forksrv, path_to_write_seed, create_info.afl_shm_size,
         create_info.bb_shm_size, true));
-    std::unique_ptr<NativeLinuxExecutor> executor2(new NativeLinuxExecutor(
+    auto executor1 = std::make_unique<LibFuzzerExecutorInterface>(std::move(nle1));
+    std::shared_ptr<NativeLinuxExecutor> nle2(new NativeLinuxExecutor(
         {FUZZUF_FUZZTOYS_DIR "/fuzz_toys-csv", output_file_path.string()},
         create_info.exec_timelimit_ms, create_info.exec_memlimit,
         create_info.forksrv, path_to_write_seed, create_info.afl_shm_size,
         create_info.bb_shm_size, true));
+    auto executor2 = std::make_unique<LibFuzzerExecutorInterface>(std::move(nle2));
     std::size_t solution_count = 0u;
     ne::known_outputs_t known;
     for (const auto &filename :

--- a/test/cli/parser.cpp
+++ b/test/cli/parser.cpp
@@ -153,10 +153,11 @@ BOOST_AUTO_TEST_CASE(BuildAFLByParsingGlobalOptionAndPUT) {
     };
 
     using AFLState = fuzzuf::algorithm::afl::AFLState;
+    using fuzzuf::executor::AFLExecutorInterface;
 
     // Parse global options and PUT, and build fuzzer
     auto fuzzer_args = ParseGlobalOptionsForFuzzer(args, options);
-    auto fuzzer = BuildAFLFuzzerFromArgs<AFLFuzzerStub<AFLState>, AFLFuzzerStub<AFLState>>(
+    auto fuzzer = BuildAFLFuzzerFromArgs<AFLFuzzerStub<AFLState>, AFLFuzzerStub<AFLState>, AFLExecutorInterface>(
             fuzzer_args, options
         );
 
@@ -191,10 +192,11 @@ BOOST_AUTO_TEST_CASE(BuildAFLByParsingGlobalOptionAndFuzzerOptionAndPUT) {
     };
 
     using AFLState = fuzzuf::algorithm::afl::AFLState;
+    using fuzzuf::executor::AFLExecutorInterface;
 
     // Parse global options and PUT, and build fuzzer
     auto fuzzer_args = ParseGlobalOptionsForFuzzer(args, options);
-    auto fuzzer = BuildAFLFuzzerFromArgs<AFLFuzzerStub<AFLState>, AFLFuzzerStub<AFLState>>(
+    auto fuzzer = BuildAFLFuzzerFromArgs<AFLFuzzerStub<AFLState>, AFLFuzzerStub<AFLState>, AFLExecutorInterface>(
             fuzzer_args, options
         );
 
@@ -214,6 +216,7 @@ BOOST_AUTO_TEST_CASE(BuildAFLByParsingGlobalOptionAndFuzzerOptionAndPUT) {
 
 BOOST_AUTO_TEST_CASE(BuildAFLFastByParsingGlobalOptionAndPUT) {
     using AFLFastState = fuzzuf::algorithm::aflfast::AFLFastState;
+    using fuzzuf::executor::AFLExecutorInterface;
     GlobalFuzzerOptions options;
     #pragma GCC diagnostic ignored "-Wwrite-strings"
     // 本来はschedule用のオプションもテストされるべきだが、CLI側の改修が必要なので一旦放置
@@ -236,7 +239,7 @@ BOOST_AUTO_TEST_CASE(BuildAFLFastByParsingGlobalOptionAndPUT) {
 
     // Parse global options and PUT, and build fuzzer
     auto fuzzer_args = ParseGlobalOptionsForFuzzer(args, options);
-    auto fuzzer = BuildAFLFastFuzzerFromArgs<AFLFuzzerStub<AFLFastState>, AFLFuzzerStub<AFLFastState>>(
+    auto fuzzer = BuildAFLFastFuzzerFromArgs<AFLFuzzerStub<AFLFastState>, AFLFuzzerStub<AFLFastState>, AFLExecutorInterface>(
             fuzzer_args, options
         );
 


### PR DESCRIPTION
<!-- Set a title that summarizes the PR changes. -->

## Type of PR
<!-- This project uses issue-driven development, so please take the appropriate action for each PR type. -->

- [x] Changes related to the roadmap (e.g., TODO.md) (type: A) -> Create an issue corresponding to the PR in advance, and refer to this PR in the issue.
- Changes that are not related to the roadmap
    - [ ] Change with multiple possible solutions to the issue (type: B-1) -> Create an issue corresponding to the PR in advance and refer to this PR in the issue.
    - [ ] Change with a single solution (type: B-2) -> There is no need to create an issue corresponding to the PR in advance. Please discuss it in this PR.

## Related Issue
<!-- If this PR is a PR type A/B-1, please provide a link to the corresponding issue. -->
<!-- If this PR is a PR type B-1, please write "N/A" -->
#30 

## Importance of PR
<!-- Please describe the importance of the PR in terms of the following aspects. -->

- Importance of the issue
    - [ ] Large (based on several days to weeks of discussion and verification, e.g., this issue is a blocking issue for other issues on the roadmap, etc.)
    - [x] Medium (based on a few hours to a day of discussion and verification, e.g., this issue is a blocking issue for another minor issue)
    - [ ] Small (apparent changes such as build error)
- Complexity of the solution (code, tests, etc.)
    - [ ] Large (requires several days to several weeks of review)
    - [x] Medium (requires several hours to a day of review)
    - [ ] Small (trivial changes, such as build error)

## PR Overview
<!-- Please provide a summary of this PR. -->
<!-- If this PR is a PR type A/B-1, this PR will be considered as an item in the checklist for the related issue. Please provide a link to the issue comment that contains the checklist. -->
<!-- If this PR is a PR type B-2, unnecessary to reference the issue. Please provide a summary. -->
For the background, see #30.
This PR proposes introducing "trait object" in Rust's term [1] to represent what methods must be implemented for an executor to support the algorithm. By this change, the algorithms can use executors without knowing the actual executor type since the classes abstract the executors. I implemented the introduced classes (`DynAFLCapable` and `DynLibFuzzerCapable`) using type erasure as suggested by @potetisensei. Note that this PR adds bare-type erasure classes only, so it does not affect the behaviors of the algorithm and CLI. I'm going to create another PR that introduces CLI changes for selecting executors at runtime to show the advantage of this change.

[1] https://doc.rust-lang.org/book/ch17-02-trait-objects.html

## Concerns (Optional)
<!-- If you have any concerns, please describe them clearly by filling in the relevant checklist items below. If there is anything else you would like to share with the reviewer, please include it. -->

- [x] Performance
- [x] Source Code Quality

I have several concerns about this change:

### 1. Type Erasure Implementation

I implemented the classes with type erasure on my own. This is usually discouraged because bugs in my own implementation of type erasure are difficult to debug and can lead to "shooting myself in the foot". However, I found that the implementation using boost/type_erasure did not meet our needs in this case, as the amount of code using boost was not much different from my own implementation, and error messages tended to be more difficult. For this reason, I decided to implement type erasure myself. There is room for discussion on this policy.

### 2. Performance

Because type erasure hides the actual type, runtime performance may suffer depending on compile-time optimizations. Although I have not yet measured and compared performance, I did not experience any performance degradation when running the unit test.

Please review the type erasure classes to ensure that no unnecessary copies are made. They take `std::shared_ptr<TExecutor>` as a constructor argument rather than executor itself. I believe that the executor is not created unnecessarily, but I am not sure if this implementation is correct.

### 3. Naming

These classes are placed under `include/fuzzuf/executor/traits`. I used the `traits` directory name because it is designed to be aware of Rust's trait objects, but it may cause misunderstanding because trait in C++ is a different concept from Rust's trait. If you have a better alternative directory name, please comment.

---

> The PR author should fill in the following checklist when submitting this PR.

#### Optional Entries
- [x] If this PR is a PR type A/B-1, there is a cross-link between this PR and the related issue.

#### Mandatory Entries
- [x] The PR title is a summary of the changes.
- [x] Completed each required field of the PR.

---
> The PR author should fill out the following checklist in the comments to confirm that this PR is ready to be merged

- [ ] CI is green or confirmed test run results.
- [ ] All change suggestions from reviewers have been resolved (fixed or foregone).

---
> The maintainer of this repository will set up a reviewer for each PR.
> PR reviewers should review this PR in terms of the checklist below before moving on to a detailed code review. Please comment on their initial response by filling in the checklist below.

#### Optional Entries
- [ ] The reviewer assigned more reviewers if needed.
- [ ] The reviewer noted that it is necessary to break out some of the changes in this PR into other PRs if needed.
- [ ] The reviewer noted that the initial response is insufficient if needed.

#### Mandatory Entries
- [ ] The title of this PR summarizes the changes made by this PR properly.
- [ ] The target branch of this PR is as intended.
- [ ] The reviewer understands the issues in this PR.
- [ ] The reviewer plans to review with an appropriate workload based on the importance of this PR.

---
> When the PR reviewer concludes that this PR is ready to be merged, please fill in the checklist below by posting it in the comment. If there is more than one reviewer, please do this on your own.

#### Optional Entries
- [ ] The reviewer noted that if you believe that new tests are needed to evaluate this PR, they have been noted.
- [ ] If minor refactorings are not mentioned in the PR, I understand the intent.
- [ ] If this PR is a PR type A/B-1, we have agreed on this PR's design, direction, and granularity in the related issue.

#### Mandatory Entries
- [ ] The reviewer understands how this PR addresses the issue and the specific changes.
- [ ] This PR uses the best possible issue resolution that the reviewer can think of.
- [ ] This PR is ready to be merged.
