### PR TITLE
Add SymCC support for AFL

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -410,7 +410,10 @@ set(
   cli/command_line_args.cpp
   cli/create_fuzzer_instance_from_argv.cpp
   cli/fuzzer_builder_register.cpp
+  cli/fuzzers/afl/build_afl_fuzzer_from_args.cpp
   cli/fuzzers/afl/register_afl_fuzzer.cpp
+  cli/fuzzers/afl_symcc/build_from_args.cpp
+  cli/fuzzers/afl_symcc/register_afl_symcc_fuzzer.cpp
   cli/fuzzers/aflfast/register_aflfast_fuzzer.cpp
   cli/fuzzers/die/register_die_fuzzer.cpp
   cli/fuzzers/ijon/register_ijon_fuzzer.cpp

--- a/cli/fuzzers/afl/build_afl_fuzzer_from_args.cpp
+++ b/cli/fuzzers/afl/build_afl_fuzzer_from_args.cpp
@@ -1,0 +1,12 @@
+#include <iostream>
+#include <cstdlib>
+#include <boost/program_options.hpp>
+
+namespace fuzzuf::cli::fuzzer::afl {
+[[noreturn]] void usage(const boost::program_options::options_description &desc) {
+    std::cout << "Help:" << std::endl;
+    std::cout << desc << std::endl;
+    std::exit(1);
+}
+}
+

--- a/cli/fuzzers/afl_symcc/build_from_args.cpp
+++ b/cli/fuzzers/afl_symcc/build_from_args.cpp
@@ -62,30 +62,25 @@ BuildFromArgs(const FuzzerArgs &fuzzer_args,
     symcc_args[0] = symcc_options.target_path;
   const auto symcc_dir =
       fs::absolute(fs::path(global_options.out_dir) / "symcc");
-  return std::unique_ptr<fuzzuf::algorithm::afl_symcc::AFLSymCCFuzzer>(
-      new fuzzuf::algorithm::afl_symcc::AFLSymCCFuzzer(
-          fuzzuf::cli::fuzzer::afl::BuildFuzzer<
-              fuzzuf::algorithm::afl_symcc::AFLFuzzerTemplate<
-                  fuzzuf::algorithm::afl::AFLState>,
-              fuzzuf::algorithm::afl_symcc::AFLFuzzerTemplate<
-                  fuzzuf::algorithm::afl::AFLState>,
-              fuzzuf::executor::AFLExecutorInterface>(fuzzer_args.argv[0],
-                                                      fuzzer_desc, afl_options,
-                                                      pargs, global_options),
-          std::move(symcc_options),
-          std::shared_ptr<fuzzuf::executor::AFLSymCCExecutorInterface>(
-              new fuzzuf::executor::AFLSymCCExecutorInterface(
-                  std::shared_ptr<NativeLinuxExecutor>(new NativeLinuxExecutor(
-                      std::move(symcc_args),
-                      global_options.exec_timelimit_ms.value_or(
-                          fuzzuf::algorithm::afl::option::GetExecTimeout<
-                              fuzzuf::algorithm::afl::option::AFLTag>()),
-                      global_options.exec_memlimit.value_or(
-                          fuzzuf::algorithm::afl::option::GetMemLimit<
-                              fuzzuf::algorithm::afl::option::AFLTag>()),
-                      false, fs::path(global_options.out_dir) / "cur_input", 0,
-                      0, false, {"SYMCC_OUTPUT_DIR=" + symcc_dir.string()},
-                      {symcc_dir}))))));
+  namespace as = algorithm::afl_symcc;
+  namespace afl = algorithm::afl;
+  return std::unique_ptr<as::AFLSymCCFuzzer>(new as::AFLSymCCFuzzer(
+      cli::fuzzer::afl::BuildFuzzer<as::AFLFuzzerTemplate<afl::AFLState>,
+                                    as::AFLFuzzerTemplate<afl::AFLState>,
+                                    executor::AFLExecutorInterface>(
+          fuzzer_args.argv[0], fuzzer_desc, afl_options, pargs, global_options),
+      std::move(symcc_options),
+      std::shared_ptr<executor::AFLSymCCExecutorInterface>(
+          new executor::AFLSymCCExecutorInterface(
+              std::shared_ptr<NativeLinuxExecutor>(new NativeLinuxExecutor(
+                  std::move(symcc_args),
+                  global_options.exec_timelimit_ms.value_or(
+                      afl::option::GetExecTimeout<afl::option::AFLTag>()),
+                  global_options.exec_memlimit.value_or(
+                      afl::option::GetMemLimit<afl::option::AFLTag>()),
+                  false, fs::path(global_options.out_dir) / "cur_input", 0, 0,
+                  false, {"SYMCC_OUTPUT_DIR=" + symcc_dir.string()},
+                  {symcc_dir}))))));
 }
 
 } // namespace fuzzuf::cli::fuzzer::afl_symcc

--- a/cli/fuzzers/afl_symcc/build_from_args.cpp
+++ b/cli/fuzzers/afl_symcc/build_from_args.cpp
@@ -1,0 +1,91 @@
+#include "fuzzuf/cli/fuzzer/afl_symcc/build_from_args.hpp"
+#include "fuzzuf/algorithms/afl/afl_fuzzer.hpp"
+#include "fuzzuf/algorithms/afl_symcc/fuzzer.hpp"
+#include "fuzzuf/cli/fuzzer/afl/build_afl_fuzzer_from_args.hpp"
+#include <boost/program_options.hpp>
+#include <cstdint>
+#include <string>
+#include <vector>
+
+namespace fuzzuf::cli::fuzzer::afl_symcc {
+// Used only for CLI
+std::unique_ptr<Fuzzer>
+BuildFromArgs(const FuzzerArgs &fuzzer_args,
+              const GlobalFuzzerOptions &global_options) {
+  namespace po = boost::program_options;
+  po::positional_options_description pargs_desc;
+  pargs_desc.add("fuzzer", 1);
+  pargs_desc.add("pargs", -1);
+
+  AFLFuzzerOptions afl_options;
+  SymCCOptions symcc_options;
+  po::options_description fuzzer_desc("AFL options");
+  std::vector<std::string> pargs;
+  afl_options.forksrv = true;
+  fuzzer_desc.add(fuzzer_args.global_options_description)
+      .add_options()("dict_file",
+                     po::value<std::string>(&afl_options.dict_file),
+                     "Load additional dictionary file.")(
+          "pargs", po::value<std::vector<std::string>>(&pargs),
+          "Specify PUT and args for PUT.")(
+          "frida",
+          po::value<bool>(&afl_options.frida_mode)
+              ->default_value(afl_options.frida_mode),
+          "Enable/disable frida mode. Default to false.")(
+          "symcc_target", po::value<std::string>(&symcc_options.target_path),
+          "Path to the target executable compiled by SymCC.")(
+          "symcc_freq", po::value<std::size_t>(&symcc_options.symcc_freq),
+          "SymCC execution frequency."
+          "If 0, SymCC is never executed."
+          "Otherwise, SymCC is executed if recent n local loop blocks didn't "
+          "change the corpus."
+          "Default 1.");
+
+  po::variables_map vm;
+  po::store(po::command_line_parser(fuzzer_args.argc, fuzzer_args.argv)
+                .options(fuzzer_desc)
+                .positional(pargs_desc)
+                .run(),
+            vm);
+  po::notify(vm);
+
+  if (global_options.help) {
+    fuzzuf::cli::fuzzer::afl::usage(fuzzer_desc);
+  }
+  if (!vm.count("symcc_target")) {
+    fuzzuf::cli::fuzzer::afl::usage(fuzzer_desc);
+  }
+  std::vector<std::string> symcc_args(pargs.begin(), pargs.end());
+  if (symcc_args.empty())
+    symcc_args.push_back(symcc_options.target_path);
+  else
+    symcc_args[0] = symcc_options.target_path;
+  const auto symcc_dir =
+      fs::absolute(fs::path(global_options.out_dir) / "symcc");
+  return std::unique_ptr<fuzzuf::algorithm::afl_symcc::AFLSymCCFuzzer>(
+      new fuzzuf::algorithm::afl_symcc::AFLSymCCFuzzer(
+          fuzzuf::cli::fuzzer::afl::BuildFuzzer<
+              fuzzuf::algorithm::afl_symcc::AFLFuzzerTemplate<
+                  fuzzuf::algorithm::afl::AFLState>,
+              fuzzuf::algorithm::afl_symcc::AFLFuzzerTemplate<
+                  fuzzuf::algorithm::afl::AFLState>,
+              fuzzuf::executor::AFLExecutorInterface>(fuzzer_args.argv[0],
+                                                      fuzzer_desc, afl_options,
+                                                      pargs, global_options),
+          std::move(symcc_options),
+          std::shared_ptr<fuzzuf::executor::AFLSymCCExecutorInterface>(
+              new fuzzuf::executor::AFLSymCCExecutorInterface(
+                  std::shared_ptr<NativeLinuxExecutor>(new NativeLinuxExecutor(
+                      std::move(symcc_args),
+                      global_options.exec_timelimit_ms.value_or(
+                          fuzzuf::algorithm::afl::option::GetExecTimeout<
+                              fuzzuf::algorithm::afl::option::AFLTag>()),
+                      global_options.exec_memlimit.value_or(
+                          fuzzuf::algorithm::afl::option::GetMemLimit<
+                              fuzzuf::algorithm::afl::option::AFLTag>()),
+                      false, fs::path(global_options.out_dir) / "cur_input", 0,
+                      0, false, {"SYMCC_OUTPUT_DIR=" + symcc_dir.string()},
+                      {symcc_dir}))))));
+}
+
+} // namespace fuzzuf::cli::fuzzer::afl_symcc

--- a/cli/fuzzers/afl_symcc/register_afl_symcc_fuzzer.cpp
+++ b/cli/fuzzers/afl_symcc/register_afl_symcc_fuzzer.cpp
@@ -1,7 +1,7 @@
 /*
  * fuzzuf
  * Copyright (C) 2021 Ricerca Security
- * 
+ *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as published by
  * the Free Software Foundation, either version 3 of the License, or
@@ -15,29 +15,13 @@
  * You should have received a copy of the GNU Affero General Public License
  * along with this program.  If not, see http://www.gnu.org/licenses/.
  */
-#pragma once
-#include "fuzzuf/cli/command_line_args.hpp"
-#include "fuzzuf/exceptions.hpp"
-#include "fuzzuf/utils/common.hpp"
+#include "fuzzuf/cli/fuzzer/afl_symcc/build_from_args.hpp"
+#include "fuzzuf/cli/fuzzer_builder_register.hpp"
+#include "fuzzuf/executor/afl_executor_interface.hpp"
+#include <boost/program_options.hpp>
 
-struct PutArgs {
-    std::vector<std::string> args;
-    int argc;
+namespace fuzzuf::cli::fuzzer::afl_symcc {
 
-    PutArgs(std::vector<std::string> args) :
-        args(args),
-        argc(args.size())
-        {}
+static FuzzerBuilderRegister global_afl_register("afl_symcc", BuildFromArgs);
 
-    void Check() {
-        if (args.size() == 0) {
-            throw exceptions::cli_error(Util::StrPrintf("Command line of PUT is not specified"), __FILE__, __LINE__);
-        }
-    }
-
-    std::vector<std::string>& Args() {
-        return this->args;
-    }
-};
-
-
+} // namespace fuzzuf::cli::fuzzer::afl_symcc

--- a/include/fuzzuf/algorithms/afl_symcc/fuzzer.hpp
+++ b/include/fuzzuf/algorithms/afl_symcc/fuzzer.hpp
@@ -1,0 +1,162 @@
+/*
+ * fuzzuf
+ * Copyright (C) 2021 Ricerca Security
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see http://www.gnu.org/licenses/.
+ */
+#ifndef FUZZUF_INCLUDE_ALGORITHM_AFL_SYMCC_FUZZER_HPP
+#define FUZZUF_INCLUDE_ALGORITHM_AFL_SYMCC_FUZZER_HPP
+
+#include "fuzzuf/algorithms/afl/afl_state.hpp"
+#include "fuzzuf/executor/afl_symcc_executor_interface.hpp"
+#include "fuzzuf/fuzzer/fuzzer.hpp"
+#include "fuzzuf/hierarflow/hierarflow_intermediates.hpp"
+#include "fuzzuf/hierarflow/hierarflow_node.hpp"
+#include "fuzzuf/hierarflow/hierarflow_routine.hpp"
+#include "fuzzuf/utils/common.hpp"
+#include "fuzzuf/utils/map_file.hpp"
+#include "fuzzuf/utils/sha1.hpp"
+#include "fuzzuf/utils/vfs/read_once.hpp"
+#include <array>
+#include <memory>
+#include <unordered_set>
+#include <vector>
+
+namespace fuzzuf::algorithm::afl_symcc {
+
+/**
+ * @class AFLFuzzerTemplate
+ * @brief Wrapper to afl::AFLFuzzerTemplate. This class append two member
+ * functions required to run SymCC.
+ * @tparam State AFL state type. The type is passed to afl::AFLFuzzerTemplate
+ * straightforward.
+ */
+template <typename State>
+struct AFLFuzzerTemplate : public afl::AFLFuzzerTemplate<State> {
+  /**
+   * All constructor arguments are forwarded to afl::AFLFuzzerTemplate
+   */
+  using afl::AFLFuzzerTemplate<State>::AFLFuzzerTemplate;
+
+  /**
+   * Add the input value to case_queue.
+   * @param buf pointer to the input value
+   * @param len length of the input value
+   * @return inserted value in Testcase
+   */
+  auto AddToQueue(const unsigned char *buf, std::uint32_t len) const {
+    const auto fn = Util::StrPrintf(
+        "%s/queue/id:%06u,symcc",
+        afl::AFLFuzzerTemplate<State>::state->setting->out_dir.c_str(),
+        afl::AFLFuzzerTemplate<State>::state->queued_paths);
+    return afl::AFLFuzzerTemplate<State>::state->AddToQueue(fn, buf, len,
+                                                            false);
+  }
+  /**
+   * Get input value that AFL recently used.
+   * @return input value
+   */
+  auto GetInput() const {
+    const auto fn =
+        afl::AFLFuzzerTemplate<State>::state
+            ->case_queue[afl::AFLFuzzerTemplate<State>::state->current_entry %
+                         afl::AFLFuzzerTemplate<State>::state->case_queue
+                             .size()]
+            ->input->GetPath();
+    return utils::map_file(fs::absolute(fs::path(fn)).string(), O_RDONLY, true);
+  }
+};
+
+/**
+ * @class AFLSymCCFuzzerTemplate
+ * @brief The fuzzer executes AFL and SymCC alternately.
+ * @tparam State AFL state type. The type is passed to afl::AFLFuzzerTemplate
+ * straightforward.
+ */
+template <typename State> class AFLSymCCFuzzerTemplate : public Fuzzer {
+public:
+  /**
+   * @param afl_ AFL fuzzer instance
+   * @param options_ SymCC parameters
+   * @param executor_ Executor to run target compiled by SymCC
+   */
+  AFLSymCCFuzzerTemplate(
+      std::unique_ptr<AFLFuzzerTemplate<State>> &&afl_,
+      fuzzuf::cli::fuzzer::afl_symcc::SymCCOptions &&options_,
+      std::shared_ptr<fuzzuf::executor::AFLSymCCExecutorInterface> &&executor_)
+      : afl(std::move(afl_)), cycle(0u), options(std::move(options_)),
+        executor(std::move(executor_)) {}
+  /**
+   * Call AFLFuzzerTemplate::BuildFuzzFlow()
+   */
+  virtual void BuildFuzzFlow() { afl->BuildFuzzFlow(); }
+  /**
+   * Call AFLFuzzerTemplate::OneLoop(), then execute SymCC.
+   */
+  virtual void OneLoop() {
+    afl->OneLoop();
+    ++cycle;
+    if (options.symcc_freq && cycle == options.symcc_freq) {
+      cycle = 0u;
+      RunSymCC();
+    }
+  }
+  /**
+   * Call AFLFuzzerTemplate::ReceiveStopSignal()
+   */
+  virtual void ReceiveStopSignal() { afl->ReceiveStopSignal(); }
+  /**
+   * Call AFLFuzzerTemplate::ShouldEnd()
+   */
+  virtual bool ShouldEnd() { return afl->ShouldEnd(); }
+
+private:
+  /**
+   * Execute SymCC
+   */
+  void RunSymCC() {
+    auto input = afl->GetInput();
+    {
+      const std::vector<unsigned char> temp(input.begin(), input.end());
+      executor->Run(temp.data(), temp.size());
+    }
+    auto files_ =
+        (executor->Filesystem() | fuzzuf::utils::vfs::adaptor::read_once)
+            .MmapAll();
+    for (auto &v : files_) {
+      const std::vector<unsigned char> temp(v.second.begin(), v.second.end());
+      const auto hash = utils::ToSerializedSha1(temp);
+      /*
+       * Since SymCC doesn't care known paths, multiple executions typically
+       * generate tons of same input values. To prevent inserting many same
+       * inputs to case_queue, this filteres already inserted values.
+       */
+      if (existing.find(hash) == existing.end()) {
+        existing.insert(existing.end(), hash);
+        afl->AddToQueue(temp.data(), temp.size());
+      }
+    }
+  }
+  std::unique_ptr<AFLFuzzerTemplate<State>> afl;
+  std::size_t cycle;
+  fuzzuf::cli::fuzzer::afl_symcc::SymCCOptions options;
+  std::shared_ptr<fuzzuf::executor::AFLSymCCExecutorInterface> executor;
+  std::unordered_set<std::string> existing;
+};
+
+using AFLSymCCFuzzer = AFLSymCCFuzzerTemplate<fuzzuf::algorithm::afl::AFLState>;
+
+} // namespace fuzzuf::algorithm::afl_symcc
+
+#endif

--- a/include/fuzzuf/algorithms/afl_symcc/fuzzer.hpp
+++ b/include/fuzzuf/algorithms/afl_symcc/fuzzer.hpp
@@ -57,7 +57,7 @@ struct AFLFuzzerTemplate : public afl::AFLFuzzerTemplate<State> {
    */
   auto AddToQueue(const unsigned char *buf, std::uint32_t len) const {
     const auto fn = Util::StrPrintf(
-        "%s/queue/id:%06u,symcc",
+        "%s/queue/id:%06u,op:symcc",
         afl::AFLFuzzerTemplate<State>::state->setting->out_dir.c_str(),
         afl::AFLFuzzerTemplate<State>::state->queued_paths);
     return afl::AFLFuzzerTemplate<State>::state->AddToQueue(fn, buf, len,
@@ -70,9 +70,11 @@ struct AFLFuzzerTemplate : public afl::AFLFuzzerTemplate<State> {
   auto GetInput() const {
     const auto fn =
         afl::AFLFuzzerTemplate<State>::state
-            ->case_queue[afl::AFLFuzzerTemplate<State>::state->current_entry %
-                         afl::AFLFuzzerTemplate<State>::state->case_queue
-                             .size()]
+            ->case_queue
+                [(afl::AFLFuzzerTemplate<State>::state->current_entry +
+                  afl::AFLFuzzerTemplate<State>::state->case_queue.size() -
+                  1u) %
+                 afl::AFLFuzzerTemplate<State>::state->case_queue.size()]
             ->input->GetPath();
     return utils::map_file(fs::absolute(fs::path(fn)).string(), O_RDONLY, true);
   }

--- a/include/fuzzuf/cli/fuzzer/afl_symcc/build_from_args.hpp
+++ b/include/fuzzuf/cli/fuzzer/afl_symcc/build_from_args.hpp
@@ -1,7 +1,7 @@
 /*
  * fuzzuf
  * Copyright (C) 2021 Ricerca Security
- * 
+ *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as published by
  * the Free Software Foundation, either version 3 of the License, or
@@ -15,29 +15,27 @@
  * You should have received a copy of the GNU Affero General Public License
  * along with this program.  If not, see http://www.gnu.org/licenses/.
  */
-#pragma once
-#include "fuzzuf/cli/command_line_args.hpp"
-#include "fuzzuf/exceptions.hpp"
-#include "fuzzuf/utils/common.hpp"
+#ifndef FUZZUF_INCLUDE_CLI_FUZZER_AFL_SYMCC_BUILD_AFL_SYMCC_FUZZER_FROM_ARGS_HPP
+#define FUZZUF_INCLUDE_CLI_FUZZER_AFL_SYMCC_BUILD_AFL_SYMCC_FUZZER_FROM_ARGS_HPP
+#include "fuzzuf/cli/fuzzer_args.hpp"
+#include "fuzzuf/cli/global_fuzzer_options.hpp"
+#include "fuzzuf/cli/put_args.hpp"
+#include "fuzzuf/fuzzer/fuzzer.hpp"
+#include <cstddef>
+#include <memory>
+#include <string>
 
-struct PutArgs {
-    std::vector<std::string> args;
-    int argc;
-
-    PutArgs(std::vector<std::string> args) :
-        args(args),
-        argc(args.size())
-        {}
-
-    void Check() {
-        if (args.size() == 0) {
-            throw exceptions::cli_error(Util::StrPrintf("Command line of PUT is not specified"), __FILE__, __LINE__);
-        }
-    }
-
-    std::vector<std::string>& Args() {
-        return this->args;
-    }
+namespace fuzzuf::cli::fuzzer::afl_symcc {
+struct SymCCOptions {
+  std::size_t symcc_freq = 1u;
+  std::string target_path;
 };
 
+// Used only for CLI
+std::unique_ptr<Fuzzer>
+BuildFromArgs(const FuzzerArgs &fuzzer_args,
+              const GlobalFuzzerOptions &global_options);
 
+} // namespace fuzzuf::cli::fuzzer::afl_symcc
+
+#endif

--- a/include/fuzzuf/executor/afl_symcc_executor_interface.hpp
+++ b/include/fuzzuf/executor/afl_symcc_executor_interface.hpp
@@ -1,0 +1,96 @@
+/*
+ * fuzzuf
+ * Copyright (C) 2022 Ricerca Security
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see http://www.gnu.org/licenses/.
+ */
+
+/**
+ * @file afl_symcc_executor_interface.hpp
+ * @author Ricerca Security <fuzzuf-dev@ricsec.co.jp>
+ */
+#ifndef FUZZUF_INCLUDE_EXECUTOR_AFL_SYMCC_EXECUTOR_INTERFACE_HPP
+#define FUZZUF_INCLUDE_EXECUTOR_AFL_SYMCC_EXECUTOR_INTERFACE_HPP
+#include "fuzzuf/executor/executor.hpp"
+#include "fuzzuf/utils/vfs/local_filesystem.hpp"
+#include <memory>
+
+namespace fuzzuf::executor {
+
+/**
+ * @class AFLSymCCExecutorInterface
+ * @brief Represents minimal requirements for a AFL_SymCC-capable executor.
+ * SymCC requires only Run and access to the filesystem.
+ *
+ * @note A AFL_SymCC-capable executor must have the following functions.
+ * - void Run(const u8 *buf, u32 len, u32 timeout_ms)
+ * - fuzzuf::utils::vfs::LocalFilesystem &Filesystem() const
+ */
+class AFLSymCCExecutorInterface {
+public:
+  template <class T>
+  AFLSymCCExecutorInterface(const std::shared_ptr<T> &executor)
+      : _container(new DynContainerDerived<T>(executor)) {}
+
+  template <class T>
+  AFLSymCCExecutorInterface(std::shared_ptr<T> &&executor) noexcept
+      : _container(new DynContainerDerived<T>(std::move(executor))) {}
+
+  AFLSymCCExecutorInterface(const AFLSymCCExecutorInterface &) = delete;
+  AFLSymCCExecutorInterface(AFLSymCCExecutorInterface &&) = default;
+  AFLSymCCExecutorInterface &
+  operator=(const AFLSymCCExecutorInterface &) = delete;
+  AFLSymCCExecutorInterface &operator=(AFLSymCCExecutorInterface &&) = default;
+  AFLSymCCExecutorInterface() = delete;
+
+  /// @brief Executes the executor with given inputs.
+  /// @param buf A pointer to the fuzzing input.
+  /// @param len Length of the fuzzing input.
+  /// @param timeout_ms Execution timeout in milliseconds.
+  void Run(const u8 *buf, u32 len, u32 timeout_ms = 0) {
+    _container->Run(buf, len, timeout_ms);
+  }
+  fuzzuf::utils::vfs::LocalFilesystem &Filesystem() const {
+    return _container->Filesystem();
+  }
+
+private:
+  class DynContainerBase {
+  public:
+    virtual ~DynContainerBase() {}
+    virtual void Run(const u8 *buf, u32 len, u32 timeout_ms = 0) = 0;
+    virtual fuzzuf::utils::vfs::LocalFilesystem &Filesystem() const = 0;
+  };
+  template <class T> class DynContainerDerived : public DynContainerBase {
+  public:
+    DynContainerDerived(std::shared_ptr<T> const &executor)
+        : _executor(executor) {}
+    DynContainerDerived(std::shared_ptr<T> &&executor) noexcept
+        : _executor(std::move(executor)) {}
+    void Run(const u8 *buf, u32 len, u32 timeout_ms = 0) {
+      _executor->Run(buf, len, timeout_ms);
+    }
+    fuzzuf::utils::vfs::LocalFilesystem &Filesystem() const override {
+      return _executor->Filesystem();
+    }
+
+  private:
+    std::shared_ptr<T> _executor;
+  };
+  std::unique_ptr<DynContainerBase> _container;
+};
+
+} // namespace fuzzuf::executor
+
+#endif // FUZZUF_INCLUDE_EXECUTOR_AFL_SYMCC_EXECUTOR_INTERFACE_HPP

--- a/include/fuzzuf/executor/afl_symcc_executor_interface.hpp
+++ b/include/fuzzuf/executor/afl_symcc_executor_interface.hpp
@@ -61,6 +61,11 @@ public:
   void Run(const u8 *buf, u32 len, u32 timeout_ms = 0) {
     _container->Run(buf, len, timeout_ms);
   }
+  /**
+   * Get filesystem context from the executor.
+   * @return filesystem context to access directories associated with the
+   * executor.
+   */
   fuzzuf::utils::vfs::LocalFilesystem &Filesystem() const {
     return _container->Filesystem();
   }


### PR DESCRIPTION
<!-- Set a title that summarizes the PR changes. -->

## Type of PR
<!-- This project uses issue-driven development, so please take the appropriate action for each PR type. -->

- [ ] Changes related to the roadmap (e.g., TODO.md) (type: A) -> Create an issue corresponding to the PR in advance, and refer to this PR in the issue.
- Changes that are not related to the roadmap
    - [ ] Change with multiple possible solutions to the issue (type: B-1) -> Create an issue corresponding to the PR in advance and refer to this PR in the issue.
    - [x] Change with a single solution (type: B-2) -> There is no need to create an issue corresponding to the PR in advance. Please discuss it in this PR.

## Related Issue
<!-- If this PR is a PR type A/B-1, please provide a link to the corresponding issue. -->
<!-- If this PR is a PR type B-1, please write "N/A" -->

## Importance of PR
<!-- Please describe the importance of the PR in terms of the following aspects. -->

- Importance of the issue
    - [ ] Large (based on several days to weeks of discussion and verification, e.g., this issue is a blocking issue for other issues on the roadmap, etc.)
    - [x] Medium (based on a few hours to a day of discussion and verification, e.g., this issue is a blocking issue for another minor issue)
    - [ ] Small (apparent changes such as build error)
- Complexity of the solution (code, tests, etc.)
    - [ ] Large (requires several days to several weeks of review)
    - [x] Medium (requires several hours to a day of review)
    - [ ] Small (trivial changes, such as build error)

## PR Overview
<!-- Please provide a summary of this PR. -->
<!-- If this PR is a PR type A/B-1, this PR will be considered as an item in the checklist for the related issue. Please provide a link to the issue comment that contains the checklist. -->
<!-- If this PR is a PR type B-2, unnecessary to reference the issue. Please provide a summary. -->

This change introduces new fuzzer "afl_symcc" that executes AFL and SymCC alternately.
As shown in the result below, enabling SymCC results more paths per minuite yet the cycles per minuite decreases.

```
$ ./fuzzuf afl --pargs /usr/libexec/fuzz_toys/fuzz_toys-branch -o out

                  fuzzuf american fuzzy lop 2.57b (fuzz_toys-branch)

┌─ process timing ─────────────────────────────────────┬─ overall results ─────┐
│        run time : 0 days, 0 hrs, 1 min, 0 sec        │  cycles done : 11     │
│   last new path : 0 days, 0 hrs, 1 min, 0 sec        │  total paths : 2      │
│ last uniq crash : none seen yet                      │ uniq crashes : 0      │
│  last uniq hang : none seen yet                      │   uniq hangs : 0      │
├─ cycle progress ────────────────────┬─ map coverage ─┴───────────────────────┤
│  now processing : 0 (0.00%)         │    map density : 0.00% / 0.03%         │
│ paths timed out : 0 (0.00%)         │ count coverage : 1.00 bits/tuple       │
├─ stage progress ───────────────────┼─ findings in depth ────────────────────┤
│  now trying : splice 2              │ favored paths : 2 (100.00%)            │
│ stage execs : 12/16 (75.00%)        │  new edges on : 2 (100.00%)            │
│ total execs : 19.2k                 │ total crashes : 0 (0 unique)           │
│  exec speed : 301.2/sec             │  total tmouts : 0 (0 unique)           │
├─ fuzzing strategy yields ───────────┴───────────────┬─ path geometry ────────┤
│   bit flips : 0/96, 0/94, 0/90                      │    levels : 2          │
│  byte flips : 0/12, 0/10, 0/6                       │   pending : 0          │
│ arithmetics : 0/671, 0/103, 0/0                     │  pend fav : 0          │
│  known ints : 0/64, 0/260, 0/264                    │ own finds : 1          │
│  dictionary : 0/0, 0/0, 0/0                         │  imported : n/a        │
│       havoc : 1/8832, 0/8656                        │ stability : 100.00%    │
│        trim : 25.00%/3, 0.00%                       ├────────────────────────┘
└─────────────────────────────────────────────────────┘          [cpu000: 48%]

$ ./fuzzuf afl_symcc --pargs /usr/libexec/fuzz_toys/fuzz_toys-branch --symcc_target /usr/libexec/fuzz_toys_symcc/fuzz_toys-branch -o out

                  fuzzuf american fuzzy lop 2.57b (fuzz_toys-branch)

┌─ process timing ─────────────────────────────────────┬─ overall results ─────┐
│        run time : 0 days, 0 hrs, 1 min, 0 sec        │  cycles done : 2      │
│   last new path : 0 days, 0 hrs, 0 min, 1 sec        │  total paths : 29     │
│ last uniq crash : none seen yet                      │ uniq crashes : 0      │
│  last uniq hang : none seen yet                      │   uniq hangs : 0      │
├─ cycle progress ────────────────────┬─ map coverage ─┴───────────────────────┤
│  now processing : 9* (31.03%)       │    map density : 0.00% / 0.04%         │
│ paths timed out : 0 (0.00%)         │ count coverage : 1.00 bits/tuple       │
├─ stage progress ───────────────────┼─ findings in depth ────────────────────┤
│  now trying : havoc                 │ favored paths : 4 (13.79%)             │
│ stage execs : 284/768 (36.98%)      │  new edges on : 5 (17.24%)             │
│ total execs : 26.2k                 │ total crashes : 0 (0 unique)           │
│  exec speed : 240.0/sec             │  total tmouts : 0 (0 unique)           │
├─ fuzzing strategy yields ───────────┴───────────────┬─ path geometry ────────┤
│   bit flips : 0/560, 0/551, 0/533                   │    levels : 4          │
│  byte flips : 0/70, 0/61, 0/43                      │   pending : 21         │
│ arithmetics : 0/3916, 0/1387, 0/313                 │  pend fav : 0          │
│  known ints : 0/348, 0/1470, 0/1709                 │ own finds : 4          │
│  dictionary : 0/0, 0/0, 2/18                        │  imported : n/a        │
│       havoc : 2/14.8k, 0/0                          │ stability : 100.00%    │
│        trim : 4.11%/11, 0.00%                       ├────────────────────────┘
└─────────────────────────────────────────────────────┘          [cpu000: 49%]

$ ./fuzzuf afl_symcc --pargs /usr/libexec/fuzz_toys/fuzz_toys-branch --symcc_target /usr/libexec/fuzz_toys_symcc/fuzz_toys-branch -o out --symcc_freq 5 

                  fuzzuf american fuzzy lop 2.57b (fuzz_toys-branch)

┌─ process timing ─────────────────────────────────────┬─ overall results ─────┐
│        run time : 0 days, 0 hrs, 1 min, 0 sec        │  cycles done : 3      │
│   last new path : 0 days, 0 hrs, 0 min, 17 sec       │  total paths : 11     │
│ last uniq crash : none seen yet                      │ uniq crashes : 0      │
│  last uniq hang : none seen yet                      │   uniq hangs : 0      │
├─ cycle progress ────────────────────┬─ map coverage ─┴───────────────────────┤
│  now processing : 10 (90.91%)       │    map density : 0.02% / 0.03%         │
│ paths timed out : 0 (0.00%)         │ count coverage : 1.00 bits/tuple       │
├─ stage progress ───────────────────┼─ findings in depth ────────────────────┤
│  now trying : havoc                 │ favored paths : 4 (36.36%)             │
│ stage execs : 2664/3072 (86.72%)    │  new edges on : 4 (36.36%)             │
│ total execs : 25.8k                 │ total crashes : 0 (0 unique)           │
│  exec speed : 302.0/sec             │  total tmouts : 0 (0 unique)           │
├─ fuzzing strategy yields ───────────┴───────────────┬─ path geometry ────────┤
│   bit flips : 0/480, 0/472, 0/456                   │    levels : 3          │
│  byte flips : 0/60, 0/52, 0/36                      │   pending : 4          │
│ arithmetics : 0/3352, 0/1308, 0/479                 │  pend fav : 1          │
│  known ints : 0/295, 0/1196, 0/1333                 │ own finds : 3          │
│  dictionary : 0/0, 0/0, 1/9                         │  imported : n/a        │
│       havoc : 2/11.1k, 0/2477                       │ stability : 100.00%    │
│        trim : 31.82%/15, 0.00%                      ├────────────────────────┘
└─────────────────────────────────────────────────────┘          [cpu000: 42%]
```

Since the method to incorporate SymCC is same as existing libFuzzer+SymCC, the change doesn't introduce unit tests for SymCC executor.

## Concerns (Optional)
<!-- If you have any concerns, please describe them clearly by filling in the relevant checklist items below. If there is anything else you would like to share with the reviewer, please include it. -->

- [ ] Performance
- [ ] Source Code Quality

---

> The PR author should fill in the following checklist when submitting this PR.

#### Optional Entries
- [ ] If this PR is a PR type A/B-1, there is a cross-link between this PR and the related issue.

#### Mandatory Entries
- [ ] The PR title is a summary of the changes.
- [ ] Completed each required field of the PR.

---
> The PR author should fill out the following checklist in the comments to confirm that this PR is ready to be merged

- [ ] CI is green or confirmed test run results.
- [ ] All change suggestions from reviewers have been resolved (fixed or foregone).

---
> The maintainer of this repository will set up a reviewer for each PR.
> PR reviewers should review this PR in terms of the checklist below before moving on to a detailed code review. Please comment on their initial response by filling in the checklist below.

#### Optional Entries
- [ ] The reviewer assigned more reviewers if needed.
- [ ] The reviewer noted that it is necessary to break out some of the changes in this PR into other PRs if needed.
- [ ] The reviewer noted that the initial response is insufficient if needed.

#### Mandatory Entries
- [ ] The title of this PR summarizes the changes made by this PR properly.
- [ ] The target branch of this PR is as intended.
- [ ] The reviewer understands the issues in this PR.
- [ ] The reviewer plans to review with an appropriate workload based on the importance of this PR.

---
> When the PR reviewer concludes that this PR is ready to be merged, please fill in the checklist below by posting it in the comment. If there is more than one reviewer, please do this on your own.

#### Optional Entries
- [ ] The reviewer noted that if you believe that new tests are needed to evaluate this PR, they have been noted.
- [ ] If minor refactorings are not mentioned in the PR, I understand the intent.
- [ ] If this PR is a PR type A/B-1, we have agreed on this PR's design, direction, and granularity in the related issue.

#### Mandatory Entries
- [ ] The reviewer understands how this PR addresses the issue and the specific changes.
- [ ] This PR uses the best possible issue resolution that the reviewer can think of.
- [ ] This PR is ready to be merged.
