### PR TITLE
Add support for dictionary on various algorithms

### DIFF
--- a/algorithms/afl/afl_dict_data.cpp
+++ b/algorithms/afl/afl_dict_data.cpp
@@ -15,6 +15,7 @@
  * You should have received a copy of the GNU Affero General Public License
  * along with this program.  If not, see http://www.gnu.org/licenses/.
  */
+#include <algorithm>
 #include <fuzzuf/utils/afl_dict_parser.hpp>
 #include <fuzzuf/algorithms/afl/afl_dict_data.hpp>
 
@@ -35,6 +36,18 @@ void load(
   const std::function< void( std::string&& ) > &eout
 ) {
   utils::dictionary::LoadAFLDictionary( filename_, dest, strict, eout );
+}
+
+void SortDictByLength(
+  std::vector< AFLDictData > &dict
+) {
+  std::sort(
+    dict.begin(),
+    dict.end(),
+    []( const auto &l, const auto &r ) {
+      return l.data.size() < r.data.size();
+    }
+  );
 }
 
 }

--- a/algorithms/ijon/ijon_fuzzer.cpp
+++ b/algorithms/ijon/ijon_fuzzer.cpp
@@ -154,6 +154,10 @@ void IJONFuzzer::BuildFuzzFlow() {
                                              normal_update.HardLink()
                                           || update_max.HardLink()
                                         )
+              || user_dict_insert << execute.HardLink() << (
+			      normal_update.HardLink()
+			      || update_max.HardLink()
+			      )
               || auto_dict_overwrite << execute.HardLink() << (
                                              normal_update.HardLink()
                                           || update_max.HardLink()

--- a/algorithms/vuzzer/vuzzer_mutator.cpp
+++ b/algorithms/vuzzer/vuzzer_mutator.cpp
@@ -379,7 +379,7 @@ void VUzzerMutator::OverwriteDictWord() {
     const unsigned int dict_index = rand() % dict_size;
     const auto &word = state.extras[ dict_index ].data;
     const auto word_len = word.size();
-    const int start_pos = ( len == word_len ) ? 0 : ( rand() % ( len - word_len ) );
+    const int start_pos = rand() % ( len - word_len + 1 );
     Replace( start_pos, word.data(), word.size() );
 }
 void VUzzerMutator::InsertDictWord() {

--- a/cli/fuzzers/afl_symcc/build_from_args.cpp
+++ b/cli/fuzzers/afl_symcc/build_from_args.cpp
@@ -23,9 +23,9 @@ BuildFromArgs(const FuzzerArgs &fuzzer_args,
   std::vector<std::string> pargs;
   afl_options.forksrv = true;
   fuzzer_desc.add(fuzzer_args.global_options_description)
-      .add_options()("dict_file",
-                     po::value<std::string>(&afl_options.dict_file),
-                     "Load additional dictionary file.")(
+      .add_options()("dict_file,x", 
+          po::value<std::vector<std::string>>(&afl_options.dict_file)->composing(), 
+          "Load additional dictionary file.")(
           "pargs", po::value<std::vector<std::string>>(&pargs),
           "Specify PUT and args for PUT.")(
           "frida",

--- a/include/fuzzuf/algorithms/afl/afl_dict_data.hpp
+++ b/include/fuzzuf/algorithms/afl/afl_dict_data.hpp
@@ -17,6 +17,7 @@
  */
 #pragma once
 
+#include <cstdlib>
 #include <vector>
 #include <string>
 #include <functional>
@@ -51,6 +52,10 @@ void load(
   std::vector< AFLDictData > &dest,
   bool strict,
   const std::function< void( std::string&& ) > &eout
+);
+
+void SortDictByLength(
+  std::vector< AFLDictData > &dict
 );
 
 } // fuzzuf::algorithm::afl::dictionary

--- a/include/fuzzuf/algorithms/afl/afl_option.hpp
+++ b/include/fuzzuf/algorithms/afl/afl_option.hpp
@@ -335,8 +335,8 @@ constexpr u32 GetTminSetSteps(AFLStateTemplate<Testcase>&) {
 
 /* Maximum dictionary token size (-x), in bytes: */
 template<class Testcase>
-constexpr u32 GetMaxDictFile(AFLStateTemplate<Testcase>&) { 
-    return 128;
+constexpr u32 GetMaxDictFile( AFLStateTemplate<Testcase> &state ) { 
+    return state.extras.empty() ? 0u : u32( state.extras.back().data.size() );
 }
 
 /* Length limits for auto-detected dictionary tokens: */

--- a/include/fuzzuf/algorithms/afl/templates/afl_fuzzer.hpp
+++ b/include/fuzzuf/algorithms/afl/templates/afl_fuzzer.hpp
@@ -110,6 +110,7 @@ void AFLFuzzerTemplate<State>::BuildFuzzFlow() {
           || arith << execute.HardLink() << normal_update.HardLink()
           || interest << execute.HardLink() << normal_update.HardLink()
           || user_dict_overwrite << execute.HardLink() << normal_update.HardLink()
+          || user_dict_insert << execute.HardLink() << normal_update.HardLink()
           || auto_dict_overwrite << execute.HardLink() << normal_update.HardLink()
          )
        || apply_rand_muts << (

--- a/include/fuzzuf/algorithms/afl/templates/afl_mutation_hierarflow_routines.hpp
+++ b/include/fuzzuf/algorithms/afl/templates/afl_mutation_hierarflow_routines.hpp
@@ -364,7 +364,9 @@ AFLMutCalleeRef<State> UserDictInsertTemplate<State>::operator()(
         }
 
         /* Copy head */
-        ex_tmp[i] = mutator.GetBuf()[i];
+	if( i != mutator.GetLen() ) {
+            ex_tmp[i] = mutator.GetBuf()[i];
+	}
     }
 
     u64 new_hit_cnt = state.queued_paths + state.unique_crashes;

--- a/include/fuzzuf/algorithms/vuzzer/vuzzer_mutator.hpp
+++ b/include/fuzzuf/algorithms/vuzzer/vuzzer_mutator.hpp
@@ -37,10 +37,10 @@ namespace fuzzuf::algorithm::vuzzer {
 // Hence you must not treat this as Mutator instance
 
 class VUzzerMutator : public Mutator<VUzzerState::Tag> {
+public:
+    using MutFunc = void(VUzzerMutator::*)();
 private:
-    typedef void (VUzzerMutator::*MutFunc)(void);
     typedef std::pair<std::shared_ptr<ExecInput>, std::shared_ptr<ExecInput>> (VUzzerMutator::*MutCrossFunc)(const ExecInput&);
-    static const MutFunc mutators[];
     static const MutCrossFunc crossovers[];
     
     // change at most 0-2 % of the binary with each fuzz
@@ -77,6 +77,8 @@ public:
     void EliminateDoubleNull();
     void TotallyRandom();
     void IntSlide();
+    void OverwriteDictWord();
+    void InsertDictWord();
     void DoubleFuzz();
     void DoubleFullMutate();
 

--- a/include/fuzzuf/algorithms/vuzzer/vuzzer_state.hpp
+++ b/include/fuzzuf/algorithms/vuzzer/vuzzer_state.hpp
@@ -147,6 +147,10 @@ struct VUzzerState {
     std::map<u64, std::map<u32, std::vector<u32>>> taint_cmp_all;
     std::map<u64, std::set<u32>> taint_cmp_offsets;
     std::map<u64, std::set<u32>> taint_lea_offsets;
+    
+    using AFLDictData = afl::dictionary::AFLDictData;
+    /* Extra tokens to fuzz with        */
+    std::vector<AFLDictData> extras;
 };
 
 } //namespace fuzzuf::algorithm::vuzzer

--- a/test/algorithms/afl/CMakeLists.txt
+++ b/test/algorithms/afl/CMakeLists.txt
@@ -62,3 +62,37 @@ endif()
 if( ENABLE_HEAVY_TEST )
 add_test( NAME "afl.loop" COMMAND test-afl-loop )
 endif()
+
+add_executable( test-afl-loop_with_dict loop_with_dict.cpp )
+target_link_libraries(
+  test-afl-loop_with_dict
+  test-common
+  fuzzuf
+  fuzzuf-cli-lib
+  ${FUZZUF_LIBRARIES}
+  Boost::unit_test_framework
+)
+target_include_directories(
+  test-afl-loop_with_dict
+  PRIVATE
+  ${FUZZUF_INCLUDE_DIRS}
+  ${CMAKE_SOURCE_DIR}/test/common
+)
+set_target_properties(
+  test-afl-loop_with_dict
+  PROPERTIES COMPILE_FLAGS "${ADDITIONAL_COMPILE_FLAGS_STR}"
+)
+set_target_properties(
+  test-afl-loop_with_dict
+  PROPERTIES LINK_FLAGS "${ADDITIONAL_COMPILE_FLAGS_STR}"
+)
+if( ENABLE_CLANG_TIDY )
+  set_target_properties(
+    test-afl-loop_with_dict
+    PROPERTIES
+    CXX_CLANG_TIDY "${CLANG_TIDY};${CLANG_TIDY_CONFIG_FOR_TEST}"
+  )
+endif()
+if( ENABLE_HEAVY_TEST )
+add_test( NAME "afl.loop_with_dict" COMMAND test-afl-loop_with_dict )
+endif()

--- a/test/algorithms/afl/loop_with_dict.cpp
+++ b/test/algorithms/afl/loop_with_dict.cpp
@@ -1,0 +1,72 @@
+/*
+ * fuzzuf
+ * Copyright (C) 2022 Ricerca Security
+ * 
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see http://www.gnu.org/licenses/.
+ */
+#define BOOST_TEST_MODULE afl.loop_with_dict
+#define BOOST_TEST_DYN_LINK
+#include <boost/scope_exit.hpp>
+#include <boost/test/unit_test.hpp>
+#include <iostream>
+#include <random>
+
+#include "fuzzuf/utils/filesystem.hpp"
+#include "fuzzuf/utils/workspace.hpp"
+#include "fuzzuf/cli/create_fuzzer_instance_from_argv.hpp"
+#include "move_to_program_location.hpp"
+#include "config.h"
+
+// to test both fork server mode and non fork server mode, we specify forksrv
+// via an argument
+static void AFLLoop(bool forksrv) {
+  // cd $(dirname $0)
+  MoveToProgramLocation();
+
+  // Create root directory
+  std::string root_dir_template("/tmp/fuzzuf_test.XXXXXX");
+  const auto raw_dirname = mkdtemp(root_dir_template.data());
+  if (!raw_dirname)
+    throw -1;
+  BOOST_CHECK(raw_dirname != nullptr);
+
+  auto root_dir = fs::path(raw_dirname);
+  BOOST_SCOPE_EXIT(&root_dir) {
+    // Executed on this test exit
+    fs::remove_all(root_dir);
+  }
+  BOOST_SCOPE_EXIT_END
+
+  // Create input file
+  auto put_dir = fs::path("../../put_binaries/libjpeg");
+  auto input_dir = put_dir / "seeds";
+  auto output_dir = root_dir / "output";
+
+  auto input_dir_opt  =  "--in_dir=" +  input_dir.string();
+  auto output_dir_opt = "--out_dir=" + output_dir.string();
+  const char *forksrv_opt = forksrv ? "--forksrv=1" : "--forksrv=0";
+
+  const char *argv[] = {"fuzzuf", "afl", input_dir_opt.c_str(), output_dir_opt.c_str(), forksrv_opt, "-x", TEST_DICTIONARY_DIR "/brainf_ck.dict", "-x", TEST_DICTIONARY_DIR "/test.dict", "../../put_binaries/libjpeg/libjpeg_turbo_fuzzer", "@@", nullptr};
+  int argc = static_cast<int>(sizeof(argv) / sizeof(const char *)) - 1; // subtract 1 for nullptr
+  auto fuzzer = fuzzuf::cli::CreateFuzzerInstanceFromArgv(argc, argv);
+
+  for (int i = 0; i < 1; i++) {
+    std::cout << "the " << i << "-th iteration starts" << std::endl;
+    fuzzer->OneLoop();
+  }
+}
+
+BOOST_AUTO_TEST_CASE(AFLLoopForkMode) {
+  AFLLoop(true);
+}


### PR DESCRIPTION
This commit contains following changes

* AFL

Loading multiple dictionaries is supported
"user extra (insert)" is added to to available mutators
"user extra (insert)" no longer causes buffer overrun

* AFLFast

Add support for loading dictionary
Since this algorithm uses AFL's mutator set, change for mutator is not needed

* AFL+SymCC

Add support for loading dictionary
Since this algorithm uses AFL's mutator set, change for mutator is not needed

* VUzzer

Add support for loading dictionary
Implement new mutator for inserting or overwriting by dictionary words

* IJON

Add support for loading dictionary
"user extra (insert)" is added to to available mutators

* Other algorithms

No changes
Since DIE uses an external tool as mutator, it is not clear that how to implement dictionary support
Since Nautilus doesn't use random mutation in byte sequence form, dictionaries are useless on this algorithm

<!-- Set a title that summarizes the PR changes. -->

## Type of PR
<!-- This project uses issue-driven development, so please take the appropriate action for each PR type. -->

- [ ] Changes related to the roadmap (e.g., TODO.md) (type: A) -> Create an issue corresponding to the PR in advance, and refer to this PR in the issue.
- Changes that are not related to the roadmap
    - [ ] Change with multiple possible solutions to the issue (type: B-1) -> Create an issue corresponding to the PR in advance and refer to this PR in the issue.
    - [x] Change with a single solution (type: B-2) -> There is no need to create an issue corresponding to the PR in advance. Please discuss it in this PR.

## Related Issue
<!-- If this PR is a PR type A/B-1, please provide a link to the corresponding issue. -->
<!-- If this PR is a PR type B-1, please write "N/A" -->

## Importance of PR
<!-- Please describe the importance of the PR in terms of the following aspects. -->

- Importance of the issue
    - [ ] Large (based on several days to weeks of discussion and verification, e.g., this issue is a blocking issue for other issues on the roadmap, etc.)
    - [x] Medium (based on a few hours to a day of discussion and verification, e.g., this issue is a blocking issue for another minor issue)
    - [ ] Small (apparent changes such as build error)
- Complexity of the solution (code, tests, etc.)
    - [ ] Large (requires several days to several weeks of review)
    - [ ] Medium (requires several hours to a day of review)
    - [x] Small (trivial changes, such as build error)

## PR Overview
<!-- Please provide a summary of this PR. -->
<!-- If this PR is a PR type A/B-1, this PR will be considered as an item in the checklist for the related issue. Please provide a link to the issue comment that contains the checklist. -->
<!-- If this PR is a PR type B-2, unnecessary to reference the issue. Please provide a summary. -->

## Concerns (Optional)
<!-- If you have any concerns, please describe them clearly by filling in the relevant checklist items below. If there is anything else you would like to share with the reviewer, please include it. -->

- [ ] Performance
- [ ] Source Code Quality

---

> The PR author should fill in the following checklist when submitting this PR.

#### Optional Entries
- [ ] If this PR is a PR type A/B-1, there is a cross-link between this PR and the related issue.

#### Mandatory Entries
- [ ] The PR title is a summary of the changes.
- [ ] Completed each required field of the PR.

---
> The PR author should fill out the following checklist in the comments to confirm that this PR is ready to be merged

- [ ] CI is green or confirmed test run results.
- [ ] All change suggestions from reviewers have been resolved (fixed or foregone).

---
> The maintainer of this repository will set up a reviewer for each PR.
> PR reviewers should review this PR in terms of the checklist below before moving on to a detailed code review. Please comment on their initial response by filling in the checklist below.

#### Optional Entries
- [ ] The reviewer assigned more reviewers if needed.
- [ ] The reviewer noted that it is necessary to break out some of the changes in this PR into other PRs if needed.
- [ ] The reviewer noted that the initial response is insufficient if needed.

#### Mandatory Entries
- [ ] The title of this PR summarizes the changes made by this PR properly.
- [ ] The target branch of this PR is as intended.
- [ ] The reviewer understands the issues in this PR.
- [ ] The reviewer plans to review with an appropriate workload based on the importance of this PR.

---
> When the PR reviewer concludes that this PR is ready to be merged, please fill in the checklist below by posting it in the comment. If there is more than one reviewer, please do this on your own.

#### Optional Entries
- [ ] The reviewer noted that if you believe that new tests are needed to evaluate this PR, they have been noted.
- [ ] If minor refactorings are not mentioned in the PR, I understand the intent.
- [ ] If this PR is a PR type A/B-1, we have agreed on this PR's design, direction, and granularity in the related issue.

#### Mandatory Entries
- [ ] The reviewer understands how this PR addresses the issue and the specific changes.
- [ ] This PR uses the best possible issue resolution that the reviewer can think of.
- [ ] This PR is ready to be merged.
