### PR TITLE
Fix that IJON is not executing IJON actually

### DIFF
--- a/algorithms/ijon/ijon_fuzzer.cpp
+++ b/algorithms/ijon/ijon_fuzzer.cpp
@@ -46,6 +46,7 @@ IJONFuzzer::IJONFuzzer(std::unique_ptr<IJONState>&& moved_state,
     state->all_inputs.emplace_back(
         state->input_set.CreateOnDisk(state->max_dir / std::to_string(i)));
   }
+  BuildFuzzFlow();
 }
 
 IJONFuzzer::~IJONFuzzer() {}
@@ -222,6 +223,11 @@ void IJONFuzzer::OneLoop(void) {
   if (!state->setting->ignore_finds && IjonShouldSchedule()) {
     ijon_fuzz_loop();
   } else {
+    // Since AFL handles end of seeds, the prior position must be recovered.
+    if (state->current_entry_is_swapped) {
+      state->current_entry_is_swapped = false;
+      state->current_entry = state->old_current_entry;
+    }
     fuzz_loop();
   }
 }

--- a/algorithms/ijon/ijon_hierarflow_routines.cpp
+++ b/algorithms/ijon/ijon_hierarflow_routines.cpp
@@ -34,6 +34,16 @@ SelectSeed::SelectSeed(struct IJONState &state) : state(state) {}
  */
 utils::NullableRef<hierarflow::HierarFlowCallee<void(void)>>
 SelectSeed::operator()(void) {
+  // Although IJON itself doesn't use current_entry, ShowState requires the value is pointing a valid seed.
+  // So if current_entry is at the end of seeds, it must be modified temporary.
+  if (state.current_entry >= state.case_queue.size()) {
+    if( !state.current_entry_is_swapped ) {
+      state.current_entry_is_swapped = true;
+      state.old_current_entry = state.current_entry;
+    }
+    state.current_entry = 0u;
+  }
+
   utils::StdoutLogger::Println("scheduled max input!!!!");
 
   u32 idx = afl::util::UR(state.nonempty_inputs.size(), state.rand_fd);

--- a/include/fuzzuf/algorithms/ijon/ijon_state.hpp
+++ b/include/fuzzuf/algorithms/ijon/ijon_state.hpp
@@ -65,6 +65,8 @@ struct IJONState : public afl::AFLStateTemplate<IJONTestcase> {
 
   size_t num_updates = 0;
   fs::path max_dir;
+  u32 old_current_entry = 0u;
+  bool current_entry_is_swapped = false;
 };
 
 }  // namespace fuzzuf::algorithm::ijon


### PR DESCRIPTION
Due to BuildFuzzFlow is called in the constructor of AFL, IJON initialization is not called.
To avoid this problem, call BuildFuzzFlow again in the constructor of IJON.
Since the above change uncovered a buffer overrun bug in the IJON implementation, the workarround for the bug is also included.

Since the buffer overrun happens in the function to display current status on TUI, the crash will not be reproduced on CI tests or any other non-tty output scene.

Changed fuzzer has kept running for ijon-test-put1 more than 20 min with sometime displaying ijon-max on "now trying" row.

```
                 fuzzuf american fuzzy lop 2.57b-ijon (ijon-test_put1)

┌─ process timing ─────────────────────────────────────┬─ overall results ─────┐
│        run time : 0 days, 0 hrs, 23 min, 2 sec       │  cycles done : 1324   │
│   last new path : 0 days, 0 hrs, 23 min, 1 sec       │  total paths : 5      │
│ last uniq crash : none seen yet                      │ uniq crashes : 0      │
│  last uniq hang : 0 days, 0 hrs, 22 min, 37 sec      │   uniq hangs : 1      │
├─ cycle progress ────────────────────┬─ map coverage ─┴───────────────────────┤
│  now processing : 2 (40.00%)        │    map density : 0.04% / 0.02%         │
│ paths timed out : 0 (0.00%)         │ count coverage : 1.00 bits/tuple       │
├─ stage progress ────────────────────┼─ findings in depth ────────────────────┤
│  now trying : ijon-max              │ favored paths : 5 (100.00%)            │
│ stage execs : 228/256 (89.06%)      │  new edges on : 5 (100.00%)            │
│ total execs : 2.67M                 │ total crashes : 0 (0 unique)           │
│  exec speed : 1933/sec              │  total tmouts : 2 (1 unique)           │
├─ fuzzing strategy yields ───────────┴───────────────┬─ path geometry ────────┤
│   bit flips : 0/240, 0/235, 0/225                   │    levels : 2          │
│  byte flips : 0/30, 0/25, 0/16                      │   pending : 0          │
│ arithmetics : 0/1679, 0/1317, 0/496                 │  pend fav : 0          │
│  known ints : 0/117, 0/468, 0/518                   │ own finds : 4          │
│  dictionary : 0/0, 0/0, 0/0                         │  imported : n/a        │
│       havoc : 4/2.52M, 0/137k                       │ stability : 100.00%    │
│        trim : 70.37%/19, 0.00%                      ├────────────────────────┘
scheduled max input!!!!───────────────────────────────┘          [cpu000: 56%]
```

<!-- Set a title that summarizes the PR changes. -->

## Type of PR
<!-- This project uses issue-driven development, so please take the appropriate action for each PR type. -->

- [ ] Changes related to the roadmap (e.g., TODO.md) (type: A) -> Create an issue corresponding to the PR in advance, and refer to this PR in the issue.
- Changes that are not related to the roadmap
    - [ ] Change with multiple possible solutions to the issue (type: B-1) -> Create an issue corresponding to the PR in advance and refer to this PR in the issue.
    - [x] Change with a single solution (type: B-2) -> There is no need to create an issue corresponding to the PR in advance. Please discuss it in this PR.

## Related Issue
<!-- If this PR is a PR type A/B-1, please provide a link to the corresponding issue. -->
<!-- If this PR is a PR type B-1, please write "N/A" -->

## Importance of PR
<!-- Please describe the importance of the PR in terms of the following aspects. -->

- Importance of the issue
    - [ ] Large (based on several days to weeks of discussion and verification, e.g., this issue is a blocking issue for other issues on the roadmap, etc.)
    - [ ] Medium (based on a few hours to a day of discussion and verification, e.g., this issue is a blocking issue for another minor issue)
    - [x] Small (apparent changes such as build error)
- Complexity of the solution (code, tests, etc.)
    - [ ] Large (requires several days to several weeks of review)
    - [ ] Medium (requires several hours to a day of review)
    - [x] Small (trivial changes, such as build error)

## PR Overview
<!-- Please provide a summary of this PR. -->
<!-- If this PR is a PR type A/B-1, this PR will be considered as an item in the checklist for the related issue. Please provide a link to the issue comment that contains the checklist. -->
<!-- If this PR is a PR type B-2, unnecessary to reference the issue. Please provide a summary. -->

## Concerns (Optional)
<!-- If you have any concerns, please describe them clearly by filling in the relevant checklist items below. If there is anything else you would like to share with the reviewer, please include it. -->

- [ ] Performance
- [ ] Source Code Quality

---

> The PR author should fill in the following checklist when submitting this PR.

#### Optional Entries
- [ ] If this PR is a PR type A/B-1, there is a cross-link between this PR and the related issue.

#### Mandatory Entries
- [ ] The PR title is a summary of the changes.
- [ ] Completed each required field of the PR.

---
> The PR author should fill out the following checklist in the comments to confirm that this PR is ready to be merged

- [ ] CI is green or confirmed test run results.
- [ ] All change suggestions from reviewers have been resolved (fixed or foregone).

---
> The maintainer of this repository will set up a reviewer for each PR.
> PR reviewers should review this PR in terms of the checklist below before moving on to a detailed code review. Please comment on their initial response by filling in the checklist below.

#### Optional Entries
- [ ] The reviewer assigned more reviewers if needed.
- [ ] The reviewer noted that it is necessary to break out some of the changes in this PR into other PRs if needed.
- [ ] The reviewer noted that the initial response is insufficient if needed.

#### Mandatory Entries
- [ ] The title of this PR summarizes the changes made by this PR properly.
- [ ] The target branch of this PR is as intended.
- [ ] The reviewer understands the issues in this PR.
- [ ] The reviewer plans to review with an appropriate workload based on the importance of this PR.

---
> When the PR reviewer concludes that this PR is ready to be merged, please fill in the checklist below by posting it in the comment. If there is more than one reviewer, please do this on your own.

#### Optional Entries
- [ ] The reviewer noted that if you believe that new tests are needed to evaluate this PR, they have been noted.
- [ ] If minor refactorings are not mentioned in the PR, I understand the intent.
- [ ] If this PR is a PR type A/B-1, we have agreed on this PR's design, direction, and granularity in the related issue.

#### Mandatory Entries
- [ ] The reviewer understands how this PR addresses the issue and the specific changes.
- [ ] This PR uses the best possible issue resolution that the reviewer can think of.
- [ ] This PR is ready to be merged.
