### PR TITLE
AFL++

### DIFF
--- a/algorithms/aflplusplus/CMakeLists.txt
+++ b/algorithms/aflplusplus/CMakeLists.txt
@@ -1,0 +1,41 @@
+add_library(
+  fuzzuf_core_aflplusplus
+  STATIC
+  aflplusplus_havoc.cpp
+  aflplusplus_mutation_hierarflow_routines.cpp
+  aflplusplus_other_hierarflow_routines.cpp
+  aflplusplus_setting.cpp
+  aflplusplus_state.cpp
+  aflplusplus_testcase.cpp
+)
+
+target_include_directories(
+  fuzzuf_core_aflplusplus
+  PRIVATE
+  ${FUZZUF_INCLUDE_DIRS}
+)
+
+set_target_properties(
+  fuzzuf_core_aflplusplus
+  PROPERTIES
+  POSITION_INDEPENDENT_CODE
+  ON
+)
+
+set_target_properties(
+  fuzzuf_core_aflplusplus
+  PROPERTIES COMPILE_FLAGS "${ADDITIONAL_COMPILE_FLAGS_STR}"
+)
+
+set_target_properties(
+  fuzzuf_core_aflplusplus
+  PROPERTIES LINK_FLAGS "${ADDITIONAL_LINK_FLAGS_STR}"
+)
+
+target_link_libraries(
+  fuzzuf_core_aflplusplus
+  ${FUZZUF_LIBRARIES}
+  fuzzuf_core_afl_common
+)
+
+

--- a/algorithms/aflplusplus/aflplusplus_havoc.cpp
+++ b/algorithms/aflplusplus/aflplusplus_havoc.cpp
@@ -1,0 +1,225 @@
+/*
+ * fuzzuf
+ * Copyright (C) 2022 Ricerca Security
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see http://www.gnu.org/licenses/.
+ */
+#include "fuzzuf/algorithms/aflplusplus/aflplusplus_havoc.hpp"
+
+#include "fuzzuf/algorithms/afl/afl_dict_data.hpp"
+#include "fuzzuf/algorithms/afl/afl_mutator.hpp"
+#include "fuzzuf/algorithms/afl/afl_option.hpp"
+#include "fuzzuf/algorithms/afl/afl_util.hpp"
+#include "fuzzuf/algorithms/afl/count_classes.hpp"
+#include "fuzzuf/algorithms/aflplusplus/aflplusplus_option.hpp"
+#include "fuzzuf/mutator/havoc_case.hpp"
+#include "fuzzuf/mutator/mutator.hpp"
+#include "fuzzuf/utils/common.hpp"
+#include "fuzzuf/utils/random.hpp"
+
+namespace fuzzuf::algorithm::aflplusplus::havoc {
+
+enum AFLplusplusExtraHavocCase : u32 {
+  AFLPLUSPLUS_ADDBYTE = mutator::NUM_CASE,
+  AFLPLUSPLUS_SUBBYTE,
+  AFLPLUSPLUS_SWITCH_BYTES,
+  AFLPLUSPLUS_NUM_CASE  // number of cases in AFL++ havoc
+};
+
+/**
+ * @fn AFLplusplusGetCaseWeights
+ * Returns the weights that represent the probabilities of each case being
+ * selected in Havoc.
+ * @note Ridiculously, we need a constexpr function just in order to initialize
+ * static arrays with enum constants(i.e. to use a kind of designated
+ * initialization)
+ */
+static constexpr std::array<double, AFLPLUSPLUS_NUM_CASE>
+AFLplusplusGetCaseWeights(bool has_extras, bool has_a_extras) {
+  std::array<double, AFLPLUSPLUS_NUM_CASE> weights{};
+
+  weights[mutator::FLIP1] = 4.0;                     // case 0 ... 3
+  weights[mutator::INT8] = 4.0;                      // case 4 ... 7
+  weights[mutator::INT16_LE] = 2.0;                  // case 8 ... 9
+  weights[mutator::INT16_BE] = 2.0;                  // case 10 ... 11
+  weights[mutator::INT32_LE] = 2.0;                  // case 12 ... 13
+  weights[mutator::INT32_BE] = 2.0;                  // case 14 ... 15
+  weights[mutator::SUB8] = 4.0;                      // case 16 ... 19
+  weights[mutator::ADD8] = 4.0;                      // case 20 ... 23
+  weights[mutator::SUB16_LE] = 2.0;                  // case 24 ... 25
+  weights[mutator::SUB16_BE] = 2.0;                  // case 26 ... 27
+  weights[mutator::ADD16_LE] = 2.0;                  // case 28 ... 29
+  weights[mutator::ADD16_BE] = 2.0;                  // case 30 ... 31
+  weights[mutator::SUB32_LE] = 2.0;                  // case 32 ... 33
+  weights[mutator::SUB32_BE] = 2.0;                  // case 34 ... 35
+  weights[mutator::ADD32_LE] = 2.0;                  // case 36 ... 37
+  weights[mutator::ADD32_BE] = 2.0;                  // case 38 ... 39
+  weights[mutator::XOR] = 4.0;                       // case 40 ... 43
+  weights[mutator::CLONE_BYTES] = 3.0;               // case 44 ... 46
+  weights[mutator::INSERT_SAME_BYTE] = 1.0;          // case 47
+  weights[mutator::OVERWRITE_WITH_CHUNK] = 3.0;      // case 48 ... 50
+  weights[mutator::OVERWRITE_WITH_SAME_BYTE] = 1.0;  // case 51
+  weights[AFLPLUSPLUS_ADDBYTE] = 1.0;                // case 52
+  weights[AFLPLUSPLUS_SUBBYTE] = 1.0;                // case 53
+  weights[mutator::FLIP8] = 1.0;                     // case 54
+  weights[AFLPLUSPLUS_SWITCH_BYTES] = 2.0;           // case 55 ... 56
+  weights[mutator::DELETE_BYTES] = 8.0;              // case 57 ... 64
+
+  if (has_extras && has_a_extras) {
+    weights[mutator::INSERT_EXTRA] = 1.0;
+    weights[mutator::OVERWRITE_WITH_EXTRA] = 1.0;
+    weights[mutator::INSERT_AEXTRA] = 1.0;
+    weights[mutator::OVERWRITE_WITH_AEXTRA] = 1.0;
+  } else if (has_extras) {
+    weights[mutator::INSERT_EXTRA] = 2.0;
+    weights[mutator::OVERWRITE_WITH_EXTRA] = 2.0;
+  } else if (has_a_extras) {
+    weights[mutator::INSERT_AEXTRA] = 2.0;
+    weights[mutator::OVERWRITE_WITH_AEXTRA] = 2.0;
+  }
+
+  return weights;
+}
+
+AFLplusplusHavocCaseDistrib::AFLplusplusHavocCaseDistrib() {}
+AFLplusplusHavocCaseDistrib::~AFLplusplusHavocCaseDistrib() {}
+u32 AFLplusplusHavocCaseDistrib::CalcValue() {
+  const auto& extras = optimizer::Store::GetInstance()
+                           .Get(optimizer::keys::Extras)
+                           .value()
+                           .get();
+  const auto& a_extras = optimizer::Store::GetInstance()
+                             .Get(optimizer::keys::AutoExtras)
+                             .value()
+                             .get();
+
+  // Static part: the following part doesn't run after a fuzzing campaign
+  // starts.
+
+  constexpr std::array<double, AFLPLUSPLUS_NUM_CASE> weight_set[2][2] = {
+      {AFLplusplusGetCaseWeights(false, false),
+       AFLplusplusGetCaseWeights(false, true)},
+      {AFLplusplusGetCaseWeights(true, false),
+       AFLplusplusGetCaseWeights(true, true)}};
+
+  using fuzzuf::utils::random::WalkerDiscreteDistribution;
+  static WalkerDiscreteDistribution<u32> dists[2][2] = {
+      {WalkerDiscreteDistribution<u32>(weight_set[0][0].cbegin(),
+                                       weight_set[0][0].cend()),
+       WalkerDiscreteDistribution<u32>(weight_set[0][1].cbegin(),
+                                       weight_set[0][1].cend())},
+      {WalkerDiscreteDistribution<u32>(weight_set[1][0].cbegin(),
+                                       weight_set[1][0].cend()),
+       WalkerDiscreteDistribution<u32>(weight_set[1][1].cbegin(),
+                                       weight_set[1][1].cend())}};
+
+  // Dynamic part: the following part runs during a fuzzing campaign
+
+  bool has_extras = !extras.empty();
+  bool has_aextras = !a_extras.empty();
+  return static_cast<u32>(dists[has_extras][has_aextras]());
+}
+
+void AFLplusplusCustomCases(
+    u32 case_idx, u8*& outbuf, u32& len,
+    [[maybe_unused]] const std::vector<afl::dictionary::AFLDictData>& extras,
+    [[maybe_unused]] const std::vector<afl::dictionary::AFLDictData>&
+        a_extras) {
+  auto UR = [](u32 limit) { return afl::util::UR(limit, -1); };
+  switch (case_idx) {
+    case AFLPLUSPLUS_ADDBYTE:
+      outbuf[UR(len)]++;
+      break;
+
+    case AFLPLUSPLUS_SUBBYTE:
+      outbuf[UR(len)]--;
+      break;
+
+    case AFLPLUSPLUS_SWITCH_BYTES: {
+      if (len < 4) {
+        break;
+      }
+
+      u32 to_end, switch_to, switch_len, switch_from;
+      switch_from = UR(len);
+      do {
+        switch_to = UR(len);
+      } while (switch_from == switch_to);
+
+      if (switch_from < switch_to) {
+        switch_len = switch_to - switch_from;
+        to_end = len - switch_to;
+      } else {
+        switch_len = switch_from - switch_to;
+        to_end = len - switch_from;
+      }
+
+      switch_len = ChooseBlockLen(std::min(switch_len, to_end));
+
+      std::unique_ptr<u8[]> new_buf(new u8[switch_len]);
+
+      /* Backup */
+      memcpy(new_buf.get(), outbuf + switch_from, switch_len);
+
+      /* Switch 1 */
+      memcpy(outbuf + switch_from, outbuf + switch_to, switch_len);
+
+      /* Switch 2 */
+      memcpy(outbuf + switch_to, new_buf.get(), switch_len);
+
+      break;
+    }
+
+    default:
+      break;
+  }
+}
+
+// Temporarily copy-and-paste ChooseBlockLen() function, rather than modifying
+// all function prototypes of CustomCases. Looking for a better way to achieve
+// this...
+u32 ChooseBlockLen(u32 limit) {
+  using Tag = aflplusplus::option::AFLplusplusTag;
+  u32 min_value, max_value;
+  u32 rlim = 3ULL;
+
+  // just an alias of afl::util::UR
+  auto UR = [](u32 limit) { return afl::util::UR(limit, -1); };
+
+  switch (UR(rlim)) {
+    case 0:
+      min_value = 1;
+      max_value = afl::option::GetHavocBlkSmall<Tag>();
+      break;
+
+    case 1:
+      min_value = afl::option::GetHavocBlkSmall<Tag>();
+      max_value = afl::option::GetHavocBlkMedium<Tag>();
+      break;
+    default:
+      if (UR(10)) {
+        min_value = afl::option::GetHavocBlkMedium<Tag>();
+        max_value = afl::option::GetHavocBlkLarge<Tag>();
+      } else {
+        min_value = afl::option::GetHavocBlkLarge<Tag>();
+        max_value = afl::option::GetHavocBlkXl<Tag>();
+      }
+  }
+
+  if (min_value >= limit) min_value = 1;
+
+  return min_value + UR(std::min(max_value, limit) - min_value + 1);
+}
+
+}  // namespace fuzzuf::algorithm::aflplusplus::havoc

--- a/algorithms/aflplusplus/aflplusplus_havoc.cpp
+++ b/algorithms/aflplusplus/aflplusplus_havoc.cpp
@@ -18,7 +18,6 @@
 #include "fuzzuf/algorithms/aflplusplus/aflplusplus_havoc.hpp"
 
 #include "fuzzuf/algorithms/afl/afl_dict_data.hpp"
-#include "fuzzuf/algorithms/afl/afl_mutator.hpp"
 #include "fuzzuf/algorithms/afl/afl_option.hpp"
 #include "fuzzuf/algorithms/afl/afl_util.hpp"
 #include "fuzzuf/algorithms/afl/count_classes.hpp"
@@ -29,13 +28,6 @@
 #include "fuzzuf/utils/random.hpp"
 
 namespace fuzzuf::algorithm::aflplusplus::havoc {
-
-enum AFLplusplusExtraHavocCase : u32 {
-  AFLPLUSPLUS_ADDBYTE = mutator::NUM_CASE,
-  AFLPLUSPLUS_SUBBYTE,
-  AFLPLUSPLUS_SWITCH_BYTES,
-  AFLPLUSPLUS_NUM_CASE  // number of cases in AFL++ havoc
-};
 
 /**
  * @fn AFLplusplusGetCaseWeights

--- a/algorithms/aflplusplus/aflplusplus_mutation_hierarflow_routines.cpp
+++ b/algorithms/aflplusplus/aflplusplus_mutation_hierarflow_routines.cpp
@@ -1,0 +1,53 @@
+/*
+ * fuzzuf
+ * Copyright (C) 2022 Ricerca Security
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see http://www.gnu.org/licenses/.
+ */
+#include "fuzzuf/algorithms/aflplusplus/aflplusplus_mutation_hierarflow_routines.hpp"
+
+#include "fuzzuf/algorithms/aflplusplus/aflplusplus_havoc.hpp"
+#include "fuzzuf/algorithms/aflplusplus/aflplusplus_testcase.hpp"
+
+namespace fuzzuf::algorithm::afl::routine::mutation {
+
+using AFLplusplusTestcase = aflplusplus::AFLplusplusTestcase;
+
+// explicit specialization
+template <>
+AFLMutCalleeRef<AFLplusplusState> HavocTemplate<AFLplusplusState>::operator()(
+    AFLMutatorTemplate<AFLplusplusState>& mutator) {
+  // Declare the alias just to omit "this->" in this function.
+  auto& state = this->state;
+
+  s32 stage_max_multiplier;
+  if (state.doing_det)
+    stage_max_multiplier = option::GetHavocCyclesInit(state);
+  else
+    stage_max_multiplier = option::GetHavocCycles(state);
+
+  using afl::dictionary::AFLDictData;
+
+  if (this->DoHavoc(mutator, *state.mutop_optimizer,
+                    aflplusplus::havoc::AFLplusplusCustomCases, "more_havoc",
+                    "more_havoc", state.orig_perf, stage_max_multiplier,
+                    option::STAGE_HAVOC)) {
+    this->SetResponseValue(true);
+    return this->GoToParent();
+  }
+
+  return this->GoToDefaultNext();
+}
+
+}  // namespace fuzzuf::algorithm::afl::routine::mutation

--- a/algorithms/aflplusplus/aflplusplus_other_hierarflow_routines.cpp
+++ b/algorithms/aflplusplus/aflplusplus_other_hierarflow_routines.cpp
@@ -1,0 +1,233 @@
+/*
+ * fuzzuf
+ * Copyright (C) 2022 Ricerca Security
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see http://www.gnu.org/licenses/.
+ */
+#include "fuzzuf/algorithms/aflplusplus/aflplusplus_other_hierarflow_routines.hpp"
+
+#include <memory>
+#include <numeric>
+
+#include "fuzzuf/algorithms/aflplusplus/aflplusplus_state.hpp"
+#include "fuzzuf/algorithms/aflplusplus/aflplusplus_testcase.hpp"
+#include "fuzzuf/utils/random.hpp"
+
+namespace fuzzuf::algorithm::afl::routine::other {
+
+using AFLplusplusState = aflplusplus::AFLplusplusState;
+using AFLplusplusTestcase = aflplusplus::AFLplusplusTestcase;
+
+// explicit specialization
+template <>
+AFLMidCalleeRef<AFLplusplusState>
+ApplyDetMutsTemplate<AFLplusplusState>::operator()(
+    std::shared_ptr<AFLplusplusTestcase> testcase) {
+  // We no longer modify this testcase.
+  // So we can reload the file with mmap.
+  testcase->input->LoadByMmap();  // no need to Unload
+
+  if (!state.orig_perf && state.queued_paths > 10) {
+    this->SetResponseValue(true);
+    return abandon_entry;
+  }
+
+  /* Skip right away if -d is given, if it has not been chosen sufficiently
+     often to warrant the expensive deterministic stage (fuzz_level), or
+     if it has gone through deterministic testing in earlier, resumed runs
+     (passed_det). */
+
+  if (state.skip_deterministic ||
+      ((!testcase->passed_det) &&
+       state.orig_perf <
+           (testcase->depth * 30 <= option::GetHavocMaxMult(state) * 100
+                ? testcase->depth * 30
+                : option::GetHavocMaxMult(state) * 100)) ||
+      testcase->passed_det) {
+    state.doing_det = false;
+    return this->GoToDefaultNext();
+  }
+
+  /* Skip deterministic fuzzing if exec path checksum puts this out of scope
+     for this master instance. */
+
+  if (state.orig_perf == 0 && state.queued_paths > 10) {
+    this->SetResponseValue(true);
+    return abandon_entry;
+  }
+
+  state.doing_det = true;
+
+  auto mutator = AFLMutatorTemplate<AFLplusplusState>(*testcase->input, state);
+
+  state.stage_val_type = option::STAGE_VAL_NONE;
+
+  // this will be required in dictionary construction and eff_map construction
+  state.queue_cur_exec_cksum = testcase->exec_cksum;
+
+  // call deterministic mutations
+  // if they return true, then we should go to abandon_entry
+  auto should_abandon_entry = this->CallSuccessors(mutator);
+
+  if (should_abandon_entry) {
+    this->SetResponseValue(true);
+    return abandon_entry;
+  }
+
+  // NOTE: "if (!testcase->passed_det)" seems unnecessary to me
+  // because passed_det == 0 always holds here
+  if (!testcase->passed_det) state.MarkAsDetDone(*testcase);
+
+  return this->GoToDefaultNext();
+}
+
+// explicit specialization
+template <>
+AFLMidCalleeRef<AFLplusplusState>
+AbandonEntryTemplate<AFLplusplusState>::operator()(
+    std::shared_ptr<AFLplusplusTestcase> testcase) {
+  state.splicing_with = -1;
+
+  /* Update pending_not_fuzzed count if we made it through the calibration
+     cycle and have not seen this entry before. */
+
+  if (!state.stop_soon && !testcase->cal_failed && !testcase->WasFuzzed()) {
+    state.pending_not_fuzzed--;
+    if (testcase->favored) state.pending_favored--;
+  }
+
+  testcase->fuzz_level++;
+
+  testcase->input->Unload();
+
+  // ReponseValue should be set in previous steps, so do nothing here
+  return this->GoToDefaultNext();
+}
+
+// explicit specialization
+template <>
+utils::NullableRef<hierarflow::HierarFlowCallee<void(void)>>
+SelectSeedTemplate<AFLplusplusState>::operator()(void) {
+  static size_t runs_in_current_cycle = static_cast<size_t>(-1);
+  if (state.queue_cycle == 0 ||
+      runs_in_current_cycle > state.case_queue.size()) {
+    state.queue_cycle++;
+    runs_in_current_cycle = static_cast<size_t>(-1);
+    // state.current_entry = state.seek_to; // seek_to is used in resume mode
+    state.seek_to = 0;
+    state.cur_skipped_paths = 0;
+
+    state.ShowStats();
+    if (state.not_on_tty) {
+      ACTF("Entering queue cycle %llu.", state.queue_cycle);
+      fflush(stdout);
+    }
+
+    /* If we had a full queue cycle with no new finds, try
+       recombination strategies next. */
+
+    if (state.queued_paths == prev_queued) {
+      if (state.use_splicing)
+        state.cycles_wo_finds++;
+      else
+        state.use_splicing = true;
+    } else
+      state.cycles_wo_finds = 0;
+
+    prev_queued = state.queued_paths;
+
+#if 0
+        if (sync_id && queue_cycle == 1 && getenv("AFL_IMPORT_FIRST"))
+            sync_fuzzers(use_argv);
+#endif
+
+    DEBUG_ASSERT(state.current_entry < state.case_queue.size());
+  }
+
+  // possible intentional overflow
+  runs_in_current_cycle++;
+
+  if (state.prev_queued_items < state.case_queue.size()) {
+    // we have new queue entries since the last run, recreate alias table
+    state.prev_queued_items = state.case_queue.size();
+    CreateAliasTable(state);
+  }
+
+  // get the testcase indexed by state.current_entry and start mutations
+  state.current_entry = static_cast<u32>((*state.alias_probability)());
+  auto &testcase = state.case_queue[state.current_entry];
+  this->CallSuccessors(testcase);
+
+#if 0
+    auto skipped_fuzz = CallSuccessors(testcase);
+
+    if (!state.stop_soon && state.sync_id && !skipped_fuzz) {
+      if (!(state.sync_interval_cnt++ % option::GetSyncInterval(state)))
+        SyncFuzzers(use_argv);
+    }
+#endif
+
+  return this->GoToDefaultNext();
+}
+
+/* create the alias table that allows weighted random selection - expensive */
+void CreateAliasTable(AFLplusplusState &state) {
+  u32 queued_items = state.case_queue.size();
+
+  double avg_exec_us = 0.0, avg_bitmap_size = 0.0, avg_top_size = 0.0;
+  for (auto &tc : state.case_queue) {
+    avg_exec_us += tc->exec_us;
+    avg_bitmap_size += std::log(tc->bitmap_size);
+    avg_top_size += tc->tc_ref;
+  }
+  avg_exec_us /= queued_items;
+  avg_bitmap_size /= queued_items;
+  avg_top_size /= queued_items;
+
+  std::vector<double> vw;
+  std::transform(state.case_queue.begin(), state.case_queue.end(),
+                 std::back_inserter(vw), [&](auto &tc) {
+                   return ComputeWeight(state, *tc, avg_exec_us,
+                                        avg_bitmap_size, avg_top_size);
+                 });
+
+  using fuzzuf::utils::random::WalkerDiscreteDistribution;
+  state.alias_probability.reset(new WalkerDiscreteDistribution<double>(vw));
+}
+
+double ComputeWeight([[maybe_unused]] const AFLplusplusState &state,
+                     const AFLplusplusTestcase &testcase,
+                     const double &avg_exec_us, const double &avg_bitmap_size,
+                     const double &avg_top_size) {
+  double weight = 1.0;
+
+  u32 hits = state.n_fuzz[testcase.n_fuzz_entry];
+  if (likely(hits)) {
+    weight *= std::log10(hits) + 1;
+  }
+
+  weight *= (avg_exec_us / testcase.exec_us);
+  weight *= (std::log(testcase.bitmap_size) / avg_bitmap_size);
+  weight *= (1 + (testcase.tc_ref / avg_top_size));
+  if (unlikely(testcase.favored)) {
+    weight *= 5;
+  }
+  if (unlikely(!(const_cast<AFLplusplusTestcase &>(testcase).WasFuzzed()))) {
+    weight *= 2;
+  }
+
+  return weight;
+}
+
+}  // namespace fuzzuf::algorithm::afl::routine::other

--- a/algorithms/aflplusplus/aflplusplus_other_hierarflow_routines.cpp
+++ b/algorithms/aflplusplus/aflplusplus_other_hierarflow_routines.cpp
@@ -206,7 +206,7 @@ void CreateAliasTable(AFLplusplusState &state) {
   state.alias_probability.reset(new WalkerDiscreteDistribution<double>(vw));
 }
 
-double ComputeWeight([[maybe_unused]] const AFLplusplusState &state,
+double ComputeWeight(const AFLplusplusState &state,
                      const AFLplusplusTestcase &testcase,
                      const double &avg_exec_us, const double &avg_bitmap_size,
                      const double &avg_top_size) {

--- a/algorithms/aflplusplus/aflplusplus_setting.cpp
+++ b/algorithms/aflplusplus/aflplusplus_setting.cpp
@@ -1,0 +1,34 @@
+/*
+ * fuzzuf
+ * Copyright (C) 2022 Ricerca Security
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see http://www.gnu.org/licenses/.
+ */
+#include "fuzzuf/algorithms/aflplusplus/aflplusplus_setting.hpp"
+
+namespace fuzzuf::algorithm::aflplusplus {
+
+AFLplusplusSetting::AFLplusplusSetting(
+    const std::vector<std::string> &argv, const std::string &in_dir,
+    const std::string &out_dir, u32 exec_timelimit_ms, u64 exec_memlimit,
+    bool forksrv, bool dumb_mode, int cpuid_to_bind,
+    const aflfast::option::Schedule schedule, std::string &schedule_string)
+    : AFLSetting(argv, in_dir, out_dir, exec_timelimit_ms, exec_memlimit,
+                 forksrv, dumb_mode, cpuid_to_bind),
+      schedule(schedule),
+      schedule_string(schedule_string) {}
+
+AFLplusplusSetting::~AFLplusplusSetting() {}
+
+}  // namespace fuzzuf::algorithm::aflplusplus

--- a/algorithms/aflplusplus/aflplusplus_state.cpp
+++ b/algorithms/aflplusplus/aflplusplus_state.cpp
@@ -1,0 +1,732 @@
+/*
+ * fuzzuf
+ * Copyright (C) 2022 Ricerca Security
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see http://www.gnu.org/licenses/.
+ */
+#include "fuzzuf/algorithms/aflplusplus/aflplusplus_state.hpp"
+
+#include <cmath>
+#include <memory>
+
+#include "fuzzuf/algorithms/afl/afl_macro.hpp"
+#include "fuzzuf/algorithms/afl/afl_state.hpp"
+#include "fuzzuf/algorithms/aflfast/aflfast_state.hpp"
+#include "fuzzuf/algorithms/aflplusplus/aflplusplus_option.hpp"
+#include "fuzzuf/algorithms/aflplusplus/aflplusplus_setting.hpp"
+#include "fuzzuf/algorithms/aflplusplus/aflplusplus_testcase.hpp"
+#include "fuzzuf/utils/common.hpp"
+
+namespace fuzzuf::algorithm::aflplusplus {
+
+AFLplusplusState::AFLplusplusState(
+    std::shared_ptr<const AFLplusplusSetting> setting,
+    std::shared_ptr<executor::AFLExecutorInterface> executor,
+    std::unique_ptr<optimizer::Optimizer<u32>> &&mutop_optimizer)
+    : afl::AFLStateTemplate<AFLplusplusTestcase>(setting, executor,
+                                                 std::move(mutop_optimizer)),
+      setting(setting),
+      prev_queued_items(0),
+      alias_probability(nullptr) {
+  n_fuzz.reset(new u32[N_FUZZ_SIZE]);
+}
+
+std::shared_ptr<AFLplusplusTestcase> AFLplusplusState::AddToQueue(
+    const std::string &fn, const u8 *buf, u32 len, bool passed_det) {
+  std::shared_ptr<AFLplusplusTestcase> testcase =
+      AFLStateTemplate<AFLplusplusTestcase>::AddToQueue(fn, buf, len,
+                                                        passed_det);
+
+  return testcase;
+}
+
+void AFLplusplusState::UpdateBitmapScoreWithRawTrace(
+    AFLplusplusTestcase &testcase, const u8 *trace_bits, u32 map_size) {
+  u64 fuzz_p2 = fuzzuf::utils::NextP2(n_fuzz[testcase.n_fuzz_entry]);
+  u64 fav_factor = testcase.exec_us * testcase.input->GetLen();
+
+  for (u32 i = 0; i < map_size; i++) {
+    if (trace_bits[i]) {
+      if (top_rated[i]) {
+        auto &top_testcase = top_rated[i].value().get();
+
+        u64 top_rated_fuzz_p2 =
+            fuzzuf::utils::NextP2(n_fuzz[top_testcase.n_fuzz_entry]);
+        u64 factor = top_testcase.exec_us * top_testcase.input->GetLen();
+
+        if (fuzz_p2 > top_rated_fuzz_p2)
+          continue;
+        else if (fuzz_p2 == top_rated_fuzz_p2) {
+          if (fav_factor > factor) continue;
+        }
+
+        /* Looks like we're going to win. Decrease ref count for the
+           previous winner, discard its trace_bits[] if necessary. */
+        --top_testcase.tc_ref;
+        if (top_testcase.tc_ref == 0) {
+          top_testcase.trace_mini.reset();
+        }
+      }
+
+      /* Insert ourselves as the new winner. */
+
+      top_rated[i] = std::ref(testcase);
+      testcase.tc_ref++;
+
+      if (!testcase.trace_mini) {
+        testcase.trace_mini.reset(
+            new std::bitset<afl::option::GetMapSize<Tag>()>());
+
+        auto &trace_mini = *testcase.trace_mini;
+        for (u32 j = 0; j < afl::option::GetMapSize<Tag>(); j++) {
+          trace_mini[j] = trace_bits[j] != 0;
+        }
+      }
+
+      score_changed = true;
+    }
+  }
+}
+
+bool AFLplusplusState::SaveIfInteresting(
+    const u8 *buf, u32 len, feedback::InplaceMemoryFeedback &inp_feed,
+    feedback::ExitStatusFeedback &exit_status) {
+  /* Update path frequency. */
+  u32 cksum = inp_feed.CalcCksum32();
+
+  /* Saturated increment */
+  if (n_fuzz[cksum % N_FUZZ_SIZE] < 0xFFFFFFFF) {
+    n_fuzz[cksum % N_FUZZ_SIZE]++;
+  }
+
+  bool res = AFLStateTemplate<AFLplusplusTestcase>::SaveIfInteresting(
+      buf, len, inp_feed, exit_status);
+
+  if (res && (exit_status.exit_reason == crash_mode)) {
+    case_queue.back()->n_fuzz_entry = cksum % N_FUZZ_SIZE;
+    n_fuzz[case_queue.back()->n_fuzz_entry] = 1;
+  }
+
+  return res;
+}
+
+u32 AFLplusplusState::DoCalcScore(AFLplusplusTestcase &testcase) {
+  u32 avg_exec_us = total_cal_us / total_cal_cycles;
+  u32 avg_bitmap_size = total_bitmap_size / total_bitmap_entries;
+  u32 perf_score = 100;
+
+  /* Adjust score based on execution speed of this path, compared to the
+     global average. Multiplier ranges from 0.1x to 3x. Fast inputs are
+     less expensive to fuzz, so we're giving them more air time. */
+
+  if (testcase.exec_us * 0.1 > avg_exec_us)
+    perf_score = 10;
+  else if (testcase.exec_us * 0.25 > avg_exec_us)
+    perf_score = 25;
+  else if (testcase.exec_us * 0.5 > avg_exec_us)
+    perf_score = 50;
+  else if (testcase.exec_us * 0.75 > avg_exec_us)
+    perf_score = 75;
+  else if (testcase.exec_us * 4 < avg_exec_us)
+    perf_score = 300;
+  else if (testcase.exec_us * 3 < avg_exec_us)
+    perf_score = 200;
+  else if (testcase.exec_us * 2 < avg_exec_us)
+    perf_score = 150;
+
+  /* Adjust score based on bitmap size. The working theory is that better
+     coverage translates to better targets. Multiplier from 0.25x to 3x. */
+
+  if (testcase.bitmap_size * 0.3 > avg_bitmap_size)
+    perf_score *= 3;
+  else if (testcase.bitmap_size * 0.5 > avg_bitmap_size)
+    perf_score *= 2;
+  else if (testcase.bitmap_size * 0.75 > avg_bitmap_size)
+    perf_score *= 1.5;
+  else if (testcase.bitmap_size * 3 < avg_bitmap_size)
+    perf_score *= 0.25;
+  else if (testcase.bitmap_size * 2 < avg_bitmap_size)
+    perf_score *= 0.5;
+  else if (testcase.bitmap_size * 1.5 < avg_bitmap_size)
+    perf_score *= 0.75;
+
+  /* Adjust score based on handicap. Handicap is proportional to how late
+     in the game we learned about this path. Latecomers are allowed to run
+     for a bit longer until they catch up with the rest. */
+
+  if (testcase.handicap >= 4) {
+    perf_score *= 4;
+    testcase.handicap -= 4;
+  } else if (testcase.handicap) {
+    perf_score *= 2;
+    testcase.handicap--;
+  }
+
+  /* Final adjustment based on input depth, under the assumption that fuzzing
+     deeper test cases is more likely to reveal stuff that can't be
+     discovered with traditional fuzzers. */
+
+  switch (testcase.depth) {
+    case 0 ... 3:
+      break;
+    case 4 ... 7:
+      perf_score *= 2;
+      break;
+    case 8 ... 13:
+      perf_score *= 3;
+      break;
+    case 14 ... 25:
+      perf_score *= 4;
+      break;
+    default:
+      perf_score *= 5;
+      break;
+  }
+
+  u32 n_paths, fuzz_mu;
+  double factor = 1.0;
+  u32 divisor;
+
+  switch (setting->schedule) {
+    case aflfast::option::EXPLORE:
+      break;
+
+    case aflfast::option::EXPLOIT:
+      factor = aflfast::option::GetMaxFactor(*this);
+      break;
+
+    case aflfast::option::COE:
+      // Don't modify perf_score for unfuzzed seeds
+      if (!testcase.fuzz_level) break;
+      fuzz_mu = 0.0;
+      n_paths = 0;
+
+      for (const auto &tc : case_queue) {
+        fuzz_mu += std::log2(n_fuzz[tc->n_fuzz_entry]);
+        n_paths++;
+      }
+
+      fuzz_mu = fuzz_mu / n_paths;
+
+      if (std::log2(n_fuzz[testcase.n_fuzz_entry]) > fuzz_mu) {
+        if (!testcase.favored) factor = 0;
+        break;
+      }
+      [[fallthrough]];
+
+    case aflfast::option::FAST:
+      // Don't modify unfuzzed seeds
+      if (!testcase.fuzz_level) break;
+
+      switch (static_cast<u32>(std::log2(n_fuzz[testcase.n_fuzz_entry]))) {
+        case 0 ... 1:
+          factor = 4.0;
+          break;
+        case 2 ... 3:
+          factor = 3.0;
+          break;
+        case 4:
+          factor = 2.0;
+          break;
+        case 5:
+          break;
+        case 6:
+          if (!testcase.favored) factor = 0.8;
+          break;
+        case 7:
+          if (!testcase.favored) factor = 0.6;
+          break;
+        default:
+          if (!testcase.favored) factor = 0.4;
+          break;
+      }
+
+      if (testcase.favored) factor *= 1.15;
+      break;
+
+    case aflfast::option::LIN:
+      // Avoid possible div by zero
+      divisor = n_fuzz[testcase.n_fuzz_entry];
+      if (divisor != 0xFFFFFFFF) divisor++;
+      factor = testcase.fuzz_level / static_cast<double>(divisor);
+      break;
+
+    case aflfast::option::QUAD:
+      divisor = n_fuzz[testcase.n_fuzz_entry];
+      if (divisor != 0xFFFFFFFF) divisor++;
+      factor = testcase.fuzz_level * testcase.fuzz_level / static_cast<double>(divisor);
+      break;
+
+    default:
+      ERROR("Unknown Power Schedule");
+  }
+
+  if (factor > aflfast::option::GetMaxFactor(*this)) {
+    factor = aflfast::option::GetMaxFactor(*this);
+  }
+
+  perf_score *= factor / aflfast::option::GetPowerBeta(*this);
+
+  /* Make sure that we don't go over limit. */
+
+  if (perf_score > afl::option::GetHavocMaxMult(*this) * 100) {
+    perf_score = afl::option::GetHavocMaxMult(*this) * 100;
+  }
+
+  return perf_score;
+}
+
+void AFLplusplusState::ShowStats(void) {
+  // Lots of constants appear, so overlook this.
+  using namespace afl::option;
+
+  const u32 MAP_SIZE = GetMapSize<Tag>();
+
+  u64 cur_ms = fuzzuf::utils::GetCurTimeMs();
+
+  /* If not enough time has passed since last UI update, bail out. */
+  if (cur_ms - last_ms < 1000 / GetUiTargetHz(*this)) return;
+
+  /* Check if we're past the 10 minute mark. */
+  if (cur_ms - start_time > 10 * 60 * 1000) run_over10m = true;
+
+  /* Calculate smoothed exec speed stats. */
+  if (last_execs == 0) {
+    avg_exec = ((double)total_execs) * 1000 / (cur_ms - start_time);
+  } else {
+    double cur_avg =
+        ((double)(total_execs - last_execs)) * 1000 / (cur_ms - last_ms);
+
+    /* If there is a dramatic (5x+) jump in speed, reset the indicator
+       more quickly. */
+    if (cur_avg * 5 < avg_exec || cur_avg / 5 > avg_exec) avg_exec = cur_avg;
+
+    avg_exec = avg_exec * (1.0 - 1.0 / GetAvgSmoothing(*this)) +
+               cur_avg * (1.0 / GetAvgSmoothing(*this));
+  }
+
+  last_ms = cur_ms;
+  last_execs = total_execs;
+
+  /* Tell the callers when to contact us (as measured in execs). */
+  stats_update_freq = avg_exec / (GetUiTargetHz(*this) * 10);
+  if (!stats_update_freq) stats_update_freq = 1;
+
+  /* Do some bitmap stats. */
+  u32 t_bytes =
+      fuzzuf::utils::CountNon255Bytes(&virgin_bits[0], virgin_bits.size());
+  double t_byte_ratio = ((double)t_bytes * 100) / MAP_SIZE;
+
+  double stab_ratio;
+  if (t_bytes)
+    stab_ratio = 100 - ((double)var_byte_count) * 100 / t_bytes;
+  else
+    stab_ratio = 100;
+
+  /* Roughly every minute, update fuzzer stats and save auto tokens. */
+  if (cur_ms - last_stats_ms > GetStatsUpdateSec(*this) * 1000) {
+    last_stats_ms = cur_ms;
+
+    WriteStatsFile(t_byte_ratio, stab_ratio, avg_exec);
+    SaveAuto();
+    WriteBitmap();
+  }
+
+  /* Every now and then, write plot data. */
+  if (cur_ms - last_plot_ms > GetPlotUpdateSec(*this) * 1000) {
+    last_plot_ms = cur_ms;
+    MaybeUpdatePlotFile(t_byte_ratio, avg_exec);
+  }
+
+  /* Honor AFL_EXIT_WHEN_DONE and AFL_BENCH_UNTIL_CRASH. */
+  if (!setting->dumb_mode && cycles_wo_finds > 100 && !pending_not_fuzzed &&
+      getenv("AFL_EXIT_WHEN_DONE"))
+    stop_soon = 2;
+
+  if (total_crashes && getenv("AFL_BENCH_UNTIL_CRASH")) stop_soon = 2;
+
+  /* If we're not on TTY, bail out. */
+  if (not_on_tty) return;
+
+  /* Compute some mildly useful bitmap stats. */
+  u32 t_bits = (MAP_SIZE << 3) -
+               fuzzuf::utils::CountBits(&virgin_bits[0], virgin_bits.size());
+
+  /* Now, for the visuals... */
+  bool term_too_small = false;
+  if (clear_screen) {
+    MSG(TERM_CLEAR);
+    clear_screen = false;
+
+    term_too_small = afl::CheckTermSize();
+  }
+
+  MSG(TERM_HOME);
+
+  if (term_too_small) {
+    MSG(cBRI
+        "Your terminal is too small to display the UI.\n"
+        "Please resize terminal window to at least 80x25.\n" cRST);
+
+    return;
+  }
+
+  // FIXME: use stringstream...?
+  // anyways it's weird to mix up sprintf and std::string
+
+  /* Let's start by drawing a centered banner. */
+  u32 banner_len =
+      (crash_mode != feedback::PUTExitReasonType::FAULT_NONE ? 24 : 22) +
+      strlen(GetVersion(*this)) + use_banner.size();
+  u32 banner_pad = (80 - banner_len) / 2;
+
+  std::string afl_name =
+      fuzzuf::utils::StrPrintf(cYEL "fuzzuf american fuzzy lop++ (%s)",
+                               setting->schedule_string.c_str());
+  auto fuzzer_name = crash_mode != feedback::PUTExitReasonType::FAULT_NONE
+                         ? cPIN "fuzzuf peruvian were-rabbit"
+                         : afl_name.c_str();
+
+  std::string tmp(banner_pad, ' ');
+  tmp += fuzzuf::utils::StrPrintf("%s " cLCY "%s" cLGN " (%s)", fuzzer_name,
+                                  GetVersion(*this), use_banner.c_str());
+  MSG("\n%s\n\n", tmp.c_str());
+
+  /* Lord, forgive me this. */
+  MSG(SET_G1 bSTG bLT bH bSTOP cCYA
+      " process timing " bSTG bH30 bH5 bH2 bHB bH bSTOP cCYA
+      " overall results " bSTG bH5 bRT "\n");
+
+  std::string col;
+  if (setting->dumb_mode) {
+    col = cRST;
+  } else {
+    u64 min_wo_finds = (cur_ms - last_path_time) / 1000 / 60;
+
+    if (queue_cycle == 1 || min_wo_finds < 15) {
+      /* First queue cycle: don't stop now! */
+      col = cMGN;
+    } else if (cycles_wo_finds < 25 || min_wo_finds < 30) {
+      /* Subsequent cycles, but we're still making finds. */
+      col = cYEL;
+    } else if (cycles_wo_finds > 100 && !pending_not_fuzzed &&
+               min_wo_finds > 120) {
+      /* No finds for a long time and no test cases to try. */
+      col = cLGN;
+    } else {
+      /* Default: cautiously OK to stop? */
+      col = cLBL;
+    }
+  }
+
+  // From here, we use these a lot...!
+  using afl::util::DescribeFloat;
+  using afl::util::DescribeInteger;
+  using afl::util::DescribeTimeDelta;
+
+  MSG(bV bSTOP "        run time : " cRST "%-34s " bSTG bV bSTOP
+               "  cycles done : %s%-5s  " bSTG bV "\n",
+      DescribeTimeDelta(cur_ms, start_time).c_str(), col.c_str(),
+      DescribeInteger(queue_cycle - 1).c_str());
+
+  /* We want to warn people about not seeing new paths after a full cycle,
+     except when resuming fuzzing or running in non-instrumented mode. */
+
+  if (!setting->dumb_mode &&
+      (last_path_time || resuming_fuzz || queue_cycle == 1 ||
+       !in_bitmap.empty() ||
+       crash_mode != feedback::PUTExitReasonType::FAULT_NONE)) {
+    MSG(bV bSTOP "   last new path : " cRST "%-34s ",
+        DescribeTimeDelta(cur_ms, last_path_time).c_str());
+
+  } else {
+    if (setting->dumb_mode) {
+      MSG(bV bSTOP "   last new path : " cPIN "n/a" cRST
+                   " (non-instrumented mode)        ");
+    } else {
+      MSG(bV bSTOP "   last new path : " cRST "none yet " cLRD
+                   "(odd, check syntax!)      ");
+    }
+  }
+
+  MSG(bSTG bV bSTOP "  total paths : " cRST "%-5s  " bSTG bV "\n",
+      DescribeInteger(queued_paths).c_str());
+
+  /* Highlight crashes in red if found, denote going over the KEEP_UNIQUE_CRASH
+     limit with a '+' appended to the count. */
+
+  tmp = DescribeInteger(unique_crashes);
+  if (unique_crashes >= GetKeepUniqueCrash(*this)) tmp += '+';
+
+  MSG(bV bSTOP " last uniq crash : " cRST "%-34s " bSTG bV bSTOP
+               " uniq crashes : %s%-6s " bSTG bV "\n",
+      DescribeTimeDelta(cur_ms, last_crash_time).c_str(),
+      unique_crashes ? cLRD : cRST, tmp.c_str());
+
+  tmp = DescribeInteger(unique_hangs);
+  if (unique_hangs >= GetKeepUniqueHang(*this)) tmp += '+';
+
+  MSG(bV bSTOP "  last uniq hang : " cRST "%-34s " bSTG bV bSTOP
+               "   uniq hangs : " cRST "%-6s " bSTG bV "\n",
+      DescribeTimeDelta(cur_ms, last_hang_time).c_str(), tmp.c_str());
+
+  MSG(bVR bH bSTOP cCYA " cycle progress " bSTG bH20 bHB bH bSTOP cCYA
+                        " map coverage " bSTG bH bHT bH20 bH2 bH bVL "\n");
+
+  /* This gets funny because we want to print several variable-length variables
+     together, but then cram them into a fixed-width field - so we need to
+     put them in a temporary buffer first. */
+
+  auto &queue_cur = *case_queue[current_entry];
+
+  tmp = DescribeInteger(current_entry);
+  tmp += queue_cur.favored ? "." : "*";
+  tmp += fuzzuf::utils::StrPrintf("%d", queue_cur.fuzz_level);
+  tmp += fuzzuf::utils::StrPrintf(" (%0.02f%%)",
+                                  ((double)current_entry * 100) / queued_paths);
+
+  MSG(bV bSTOP "  now processing : " cRST "%-17s " bSTG bV bSTOP, tmp.c_str());
+
+  tmp = fuzzuf::utils::StrPrintf(
+      "%0.02f%% / %0.02f%%", ((double)queue_cur.bitmap_size) * 100 / MAP_SIZE,
+      t_byte_ratio);
+
+  MSG("    map density : %s%-21s " bSTG bV "\n",
+      t_byte_ratio > 70
+          ? cLRD
+          : ((t_bytes < 200 && !setting->dumb_mode) ? cPIN : cRST),
+      tmp.c_str());
+
+  tmp = DescribeInteger(cur_skipped_paths);
+  tmp += fuzzuf::utils::StrPrintf(
+      " (%0.02f%%)", ((double)cur_skipped_paths * 100) / queued_paths);
+
+  MSG(bV bSTOP " paths timed out : " cRST "%-17s " bSTG bV, tmp.c_str());
+
+  tmp = fuzzuf::utils::StrPrintf("%0.02f bits/tuple",
+                                 t_bytes ? (((double)t_bits) / t_bytes) : 0);
+
+  MSG(bSTOP " count coverage : " cRST "%-21s " bSTG bV "\n", tmp.c_str());
+
+  MSG(bVR bH bSTOP cCYA " stage progress " bSTG bH20 bX bH bSTOP cCYA
+                        " findings in depth " bSTG bH20 bVL "\n");
+
+  tmp = DescribeInteger(queued_favored);
+  tmp += fuzzuf::utils::StrPrintf(
+      " (%0.02f%%)", ((double)queued_favored) * 100 / queued_paths);
+
+  /* Yeah... it's still going on... halp? */
+
+  MSG(bV bSTOP "  now trying : " cRST "%-21s " bSTG bV bSTOP
+               " favored paths : " cRST "%-22s " bSTG bV "\n",
+      stage_name.c_str(), tmp.c_str());
+
+  if (!stage_max) {
+    tmp = DescribeInteger(stage_cur) + "/-";
+  } else {
+    tmp = DescribeInteger(stage_cur) + "/" + DescribeInteger(stage_max);
+    tmp += fuzzuf::utils::StrPrintf(" (%0.02f%%)",
+                                    ((double)stage_cur) * 100 / stage_max);
+  }
+
+  MSG(bV bSTOP " stage execs : " cRST "%-21s " bSTG bV bSTOP, tmp.c_str());
+
+  tmp = DescribeInteger(queued_with_cov);
+  tmp += fuzzuf::utils::StrPrintf(
+      " (%0.02f%%)", ((double)queued_with_cov) * 100 / queued_paths);
+
+  MSG("  new edges on : " cRST "%-22s " bSTG bV "\n", tmp.c_str());
+
+  tmp = DescribeInteger(total_crashes) + " (" + DescribeInteger(unique_crashes);
+  if (unique_crashes >= GetKeepUniqueCrash(*this)) tmp += '+';
+  tmp += " unique)";
+
+  if (crash_mode != feedback::PUTExitReasonType::FAULT_NONE) {
+    MSG(bV bSTOP " total execs : " cRST "%-21s " bSTG bV bSTOP
+                 "   new crashes : %s%-22s " bSTG bV "\n",
+        DescribeInteger(total_execs).c_str(), unique_crashes ? cLRD : cRST,
+        tmp.c_str());
+  } else {
+    MSG(bV bSTOP " total execs : " cRST "%-21s " bSTG bV bSTOP
+                 " total crashes : %s%-22s " bSTG bV "\n",
+        DescribeInteger(total_execs).c_str(), unique_crashes ? cLRD : cRST,
+        tmp.c_str());
+  }
+
+  /* Show a warning about slow execution. */
+
+  if (avg_exec < 100) {
+    tmp = DescribeFloat(avg_exec) + "/sec (";
+    if (avg_exec < 20)
+      tmp += "zzzz...";
+    else
+      tmp += "slow!";
+    tmp += ')';
+
+    MSG(bV bSTOP "  exec speed : " cLRD "%-21s ", tmp.c_str());
+  } else {
+    tmp = DescribeFloat(avg_exec) + "/sec";
+
+    MSG(bV bSTOP "  exec speed : " cRST "%-21s ", tmp.c_str());
+  }
+
+  tmp = DescribeInteger(total_tmouts) + " (" + DescribeInteger(unique_tmouts);
+  if (unique_hangs >= GetKeepUniqueHang(*this)) tmp += '+';
+  tmp += " unique)";
+
+  MSG(bSTG bV bSTOP "  total tmouts : " cRST "%-22s " bSTG bV "\n",
+      tmp.c_str());
+
+  /* Aaaalmost there... hold on! */
+
+  MSG(bVR bH cCYA bSTOP
+      " fuzzing strategy yields " bSTG bH10 bH bHT bH10 bH5 bHB bH bSTOP cCYA
+      " path geometry " bSTG bH5 bH2 bH bVL "\n");
+
+  // In original AFL, the following part is unrolled, which is too long.
+  // So put them into a loop as many as possible and wish compiler's
+  // optimization.
+
+  // First, define the type describing the information output in one line:
+  using OnelineInfo = std::tuple<
+      const char *,  // mut_name.      e.g. "bit flips", "arithmetics"
+      const char *,  // neighbor_name. e.g. "levels", "pending", "pend fav"
+      std::string,   // neighbor_val.  e.g. DI(max_depth),
+                     // DI(pending_not_fuzzed), DI(pending_favored)
+      u8,            // stage1.        e.g. STAGE_FLIP8, STAGE_ARITH8
+      u8,            // stage2.        e.g. STAGE_FLIP16, STAGE_ARITH16
+      u8             // stage3.        e.g. STAGE_FLIP32, STAGE_ARITH32
+      >;
+
+  // Next, define each lines
+  OnelineInfo line_infos[] = {
+      {"   bit flips", "    levels", DescribeInteger(max_depth), STAGE_FLIP1,
+       STAGE_FLIP2, STAGE_FLIP4},
+      {"  byte flips", "   pending", DescribeInteger(pending_not_fuzzed),
+       STAGE_FLIP8, STAGE_FLIP16, STAGE_FLIP32},
+      {" arithmetics", "  pend fav", DescribeInteger(pending_favored),
+       STAGE_ARITH8, STAGE_ARITH16, STAGE_ARITH32},
+      {"  known ints", " own finds", DescribeInteger(queued_discovered),
+       STAGE_INTEREST8, STAGE_INTEREST16, STAGE_INTEREST32},
+      {"  dictionary", "  imported",
+       sync_id.empty() ? "n/a" : DescribeInteger(queued_imported),
+       STAGE_EXTRAS_UO, STAGE_EXTRAS_UI,
+       STAGE_EXTRAS_AO}};  // Havoc is difficult to put together
+
+  tmp = "n/a, n/a, n/a";
+  for (int i = 0; i < 5; i++) {
+    auto [mut_name, neighbor_name, neighbor_val, stage1, stage2, stage3] =
+        line_infos[i];
+
+    if (!skip_deterministic) {
+      tmp = DescribeInteger(stage_finds[stage1]) + '/' +
+            DescribeInteger(stage_cycles[stage1]) +
+
+            ", " + DescribeInteger(stage_finds[stage2]) + '/' +
+            DescribeInteger(stage_cycles[stage2]) +
+
+            ", " + DescribeInteger(stage_finds[stage3]) + '/' +
+            DescribeInteger(stage_cycles[stage3]);
+    }
+
+    MSG(bV bSTOP "%s : " cRST "%-37s " bSTG bV bSTOP "%s : " cRST
+                 "%-10s " bSTG bV "\n",
+        mut_name, tmp.c_str(), neighbor_name, neighbor_val.c_str());
+  }
+
+  tmp = DescribeInteger(stage_finds[STAGE_HAVOC]) + '/' +
+        DescribeInteger(stage_cycles[STAGE_HAVOC]) +
+
+        ", " + DescribeInteger(stage_finds[STAGE_SPLICE]) + '/' +
+        DescribeInteger(stage_cycles[STAGE_SPLICE]);
+
+  MSG(bV bSTOP "       havoc : " cRST "%-37s " bSTG bV bSTOP, tmp.c_str());
+
+  if (t_bytes)
+    tmp = fuzzuf::utils::StrPrintf("%0.02f%%", stab_ratio);
+  else
+    tmp = "n/a";
+
+  MSG(" stability : %s%-10s " bSTG bV "\n",
+      (stab_ratio < 85 && var_byte_count > 40)
+          ? cLRD
+          : ((queued_variable && (!persistent_mode || var_byte_count > 20))
+                 ? cMGN
+                 : cRST),
+      tmp.c_str());
+
+  if (!bytes_trim_out) {
+    tmp = "n/a, ";
+  } else {
+    tmp = fuzzuf::utils::StrPrintf(
+        "%0.02f%%",
+        ((double)(bytes_trim_in - bytes_trim_out)) * 100 / bytes_trim_in);
+    tmp += "/" + DescribeInteger(trim_execs) + ", ";
+  }
+
+  if (!blocks_eff_total) {
+    tmp += "n/a";
+  } else {
+    tmp += fuzzuf::utils::StrPrintf(
+        "%0.02f%%", ((double)(blocks_eff_total - blocks_eff_select)) * 100 /
+                        blocks_eff_total);
+  }
+
+  MSG(bV bSTOP "        trim : " cRST "%-37s " bSTG bVR bH20 bH2 bH2 bRB
+               "\n" bLB bH30 bH20 bH2 bH bRB bSTOP cRST RESET_G1,
+      tmp.c_str());
+
+  /* Provide some CPU utilization stats. */
+
+  if (cpu_core_count) {
+    double cur_runnable = GetRunnableProcesses(*this);
+    u32 cur_utilization = cur_runnable * 100 / cpu_core_count;
+
+    std::string cpu_color = cCYA;
+
+    /* If we could still run one or more processes, use green. */
+
+    if (cpu_core_count > 1 && cur_runnable + 1 <= cpu_core_count)
+      cpu_color = cLGN;
+
+    /* If we're clearly oversubscribed, use red. */
+
+    if (!no_cpu_meter_red && cur_utilization >= 150) cpu_color = cLRD;
+
+#ifdef HAVE_AFFINITY
+
+    if (cpu_aff >= 0) {
+      MSG(SP10 cGRA "[cpu%03d:%s%3u%%" cGRA "]\r" cRST, std::min(cpu_aff, 999),
+          cpu_color.c_str(), std::min(cur_utilization, 999u));
+    } else {
+      MSG(SP10 cGRA "   [cpu:%s%3u%%" cGRA "]\r" cRST, cpu_color.c_str(),
+          std::min(cur_utilization, 999u));
+    }
+
+#else
+
+    MSG(SP10 cGRA "   [cpu:%s%3u%%" cGRA "]\r" cRST, cpu_color.c_str(),
+        std::min(cur_utilization, 999u));
+
+#endif /* ^HAVE_AFFINITY */
+
+  } else
+    MSG("\r");
+
+  /* Hallelujah! */
+
+  fflush(0);
+}
+
+}  // namespace fuzzuf::algorithm::aflplusplus

--- a/algorithms/aflplusplus/aflplusplus_testcase.cpp
+++ b/algorithms/aflplusplus/aflplusplus_testcase.cpp
@@ -1,0 +1,30 @@
+/*
+ * fuzzuf
+ * Copyright (C) 2022 Ricerca Security
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see http://www.gnu.org/licenses/.
+ */
+#include "fuzzuf/algorithms/aflplusplus/aflplusplus_testcase.hpp"
+
+#include "fuzzuf/exec_input/on_disk_exec_input.hpp"
+
+namespace fuzzuf::algorithm::aflplusplus {
+
+AFLplusplusTestcase::AFLplusplusTestcase(
+    std::shared_ptr<exec_input::OnDiskExecInput> input)
+    : AFLTestcase(input), n_fuzz_entry(0) {}
+
+AFLplusplusTestcase::~AFLplusplusTestcase() {}
+
+}  // namespace fuzzuf::algorithm::aflplusplus

--- a/cli/fuzzers/aflplusplus/register_aflplusplus_fuzzer.cpp
+++ b/cli/fuzzers/aflplusplus/register_aflplusplus_fuzzer.cpp
@@ -1,0 +1,35 @@
+/*
+ * fuzzuf
+ * Copyright (C) 2021 Ricerca Security
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see http://www.gnu.org/licenses/.
+ */
+#include "fuzzuf/algorithms/aflplusplus/aflplusplus_fuzzer.hpp"
+#include "fuzzuf/cli/fuzzer/aflplusplus/build_aflplusplus_fuzzer_from_args.hpp"
+#include "fuzzuf/cli/fuzzer_builder_register.hpp"
+#include "fuzzuf/executor/afl_executor_interface.hpp"
+
+namespace fuzzuf::cli::fuzzer::aflplusplus {
+
+// builder_map.insert is called before main function if the below is declared as
+// a global variable and linked as an object file. Conversely, if AFL cannot be
+// built in a certain environment, do not compile it into an object file to
+// prevent AFL from being registered by accident.
+static FuzzerBuilderRegister global_aflplusplus_register(
+    "aflplusplus",
+    BuildAFLplusplusFuzzerFromArgs<fuzzuf::fuzzer::Fuzzer,
+                                   algorithm::aflplusplus::AFLplusplusFuzzer,
+                                   executor::AFLExecutorInterface>);
+
+}  // namespace fuzzuf::cli::fuzzer::aflplusplus

--- a/include/fuzzuf/algorithms/aflplusplus/aflplusplus_fuzzer.hpp
+++ b/include/fuzzuf/algorithms/aflplusplus/aflplusplus_fuzzer.hpp
@@ -1,0 +1,49 @@
+/*
+ * fuzzuf
+ * Copyright (C) 2022 Ricerca Security
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see http://www.gnu.org/licenses/.
+ */
+
+#ifndef FUZZUF_INCLUDE_ALGORITHMS_AFLPLUSPLUS_AFLPLUSPLUS_FUZZER_HPP
+#define FUZZUF_INCLUDE_ALGORITHMS_AFLPLUSPLUS_AFLPLUSPLUS_FUZZER_HPP
+
+#include "fuzzuf/algorithms/afl/afl_fuzzer.hpp"
+#include "fuzzuf/algorithms/aflplusplus/aflplusplus_mutation_hierarflow_routines.hpp"
+#include "fuzzuf/algorithms/aflplusplus/aflplusplus_other_hierarflow_routines.hpp"
+#include "fuzzuf/algorithms/aflplusplus/aflplusplus_state.hpp"
+#include "fuzzuf/fuzzer/fuzzer.hpp"
+#include "fuzzuf/hierarflow/hierarflow_intermediates.hpp"
+#include "fuzzuf/hierarflow/hierarflow_node.hpp"
+#include "fuzzuf/hierarflow/hierarflow_routine.hpp"
+#include "fuzzuf/utils/common.hpp"
+
+namespace fuzzuf::algorithm::aflplusplus {
+
+class AFLplusplusFuzzer final
+    : public afl::AFLFuzzerTemplate<AFLplusplusState> {
+ public:
+  explicit AFLplusplusFuzzer(std::unique_ptr<AFLplusplusState>&& state)
+      : afl::AFLFuzzerTemplate<AFLplusplusState>(std::move(state)),
+        fuzz_loop(afl::BuildAFLFuzzLoop(
+            *afl::AFLFuzzerTemplate<AFLplusplusState>::state)) {}
+  virtual void OneLoop(void) override { fuzz_loop(); }
+
+ private:
+  hierarflow::HierarFlowNode<void(void), void(void)> fuzz_loop;
+};
+
+}  // namespace fuzzuf::algorithm::aflplusplus
+
+#endif

--- a/include/fuzzuf/algorithms/aflplusplus/aflplusplus_havoc.hpp
+++ b/include/fuzzuf/algorithms/aflplusplus/aflplusplus_havoc.hpp
@@ -1,0 +1,42 @@
+/*
+ * fuzzuf
+ * Copyright (C) 2022 Ricerca Security
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see http://www.gnu.org/licenses/.
+ */
+#ifndef FUZZUF_INCLUDE_ALGORITHM_AFLPLUSPLUS_AFLPLUSPLUS_HAVOC_HPP
+#define FUZZUF_INCLUDE_ALGORITHM_AFLPLUSPLUS_AFLPLUSPLUS_HAVOC_HPP
+
+#include "fuzzuf/algorithms/afl/afl_dict_data.hpp"
+#include "fuzzuf/optimizer/optimizer.hpp"
+
+namespace fuzzuf::algorithm::aflplusplus::havoc {
+
+void AFLplusplusCustomCases(
+    u32 case_idx, u8*& outbuf, u32& len,
+    const std::vector<afl::dictionary::AFLDictData>& extras,
+    const std::vector<afl::dictionary::AFLDictData>& a_extras);
+
+class AFLplusplusHavocCaseDistrib : public optimizer::Optimizer<u32> {
+ public:
+  AFLplusplusHavocCaseDistrib();
+  ~AFLplusplusHavocCaseDistrib();
+  u32 CalcValue() override;
+};
+
+u32 ChooseBlockLen(u32 limit);
+
+}  // namespace fuzzuf::algorithm::aflplusplus::havoc
+
+#endif

--- a/include/fuzzuf/algorithms/aflplusplus/aflplusplus_havoc.hpp
+++ b/include/fuzzuf/algorithms/aflplusplus/aflplusplus_havoc.hpp
@@ -19,9 +19,17 @@
 #define FUZZUF_INCLUDE_ALGORITHM_AFLPLUSPLUS_AFLPLUSPLUS_HAVOC_HPP
 
 #include "fuzzuf/algorithms/afl/afl_dict_data.hpp"
+#include "fuzzuf/algorithms/afl/afl_mutator.hpp"
 #include "fuzzuf/optimizer/optimizer.hpp"
 
 namespace fuzzuf::algorithm::aflplusplus::havoc {
+
+enum AFLplusplusExtraHavocCase : u32 {
+  AFLPLUSPLUS_ADDBYTE = mutator::NUM_CASE,
+  AFLPLUSPLUS_SUBBYTE,
+  AFLPLUSPLUS_SWITCH_BYTES,
+  AFLPLUSPLUS_NUM_CASE  // number of cases in AFL++ havoc
+};
 
 void AFLplusplusCustomCases(
     u32 case_idx, u8*& outbuf, u32& len,

--- a/include/fuzzuf/algorithms/aflplusplus/aflplusplus_mutation_hierarflow_routines.hpp
+++ b/include/fuzzuf/algorithms/aflplusplus/aflplusplus_mutation_hierarflow_routines.hpp
@@ -1,0 +1,37 @@
+/*
+ * fuzzuf
+ * Copyright (C) 2022 Ricerca Security
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see http://www.gnu.org/licenses/.
+ */
+
+#ifndef FUZZUF_INCLUDE_ALGORITHM_AFLPLUSPLUS_AFLPLUSPLUS_MUTATION_HIERARFLOW_ROUTINES_HPP
+#define FUZZUF_INCLUDE_ALGORITHM_AFLPLUSPLUS_AFLPLUSPLUS_MUTATION_HIERARFLOW_ROUTINES_HPP
+
+#include "fuzzuf/algorithms/afl/afl_mutation_hierarflow_routines.hpp"
+#include "fuzzuf/algorithms/afl/afl_mutator.hpp"
+#include "fuzzuf/algorithms/aflplusplus/aflplusplus_state.hpp"
+
+namespace fuzzuf::algorithm::afl::routine::mutation {
+
+using AFLplusplusState = aflplusplus::AFLplusplusState;
+
+// explicit specialization
+template <>
+AFLMutCalleeRef<AFLplusplusState> HavocTemplate<AFLplusplusState>::operator()(
+    AFLMutatorTemplate<AFLplusplusState>& mutator);
+
+}  // namespace fuzzuf::algorithm::afl::routine::mutation
+
+#endif

--- a/include/fuzzuf/algorithms/aflplusplus/aflplusplus_option.hpp
+++ b/include/fuzzuf/algorithms/aflplusplus/aflplusplus_option.hpp
@@ -1,0 +1,28 @@
+/*
+ * fuzzuf
+ * Copyright (C) 2022 Ricerca Security
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see http://www.gnu.org/licenses/.
+ */
+#ifndef FUZZUF_INCLUDE_ALGORITHM_AFLPLUSPLUS_AFLPLUSPLUS_OPTION_HPP
+#define FUZZUF_INCLUDE_ALGORITHM_AFLPLUSPLUS_AFLPLUSPLUS_OPTION_HPP
+
+#include "fuzzuf/algorithms/aflfast/aflfast_option.hpp"
+
+namespace fuzzuf::algorithm::aflplusplus::option {
+
+struct AFLplusplusTag {};
+
+}  // namespace fuzzuf::algorithm::aflplusplus::option
+#endif

--- a/include/fuzzuf/algorithms/aflplusplus/aflplusplus_other_hierarflow_routines.hpp
+++ b/include/fuzzuf/algorithms/aflplusplus/aflplusplus_other_hierarflow_routines.hpp
@@ -1,0 +1,56 @@
+/*
+ * fuzzuf
+ * Copyright (C) 2022 Ricerca Security
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see http://www.gnu.org/licenses/.
+ */
+#ifndef FUZZUF_INCLUDE_ALGORITHMS_AFLPLUSPLUS_AFLPLUSPLUS_OTHER_HIERARFLOW_ROUTINES_HPP
+#define FUZZUF_INCLUDE_ALGORITHMS_AFLPLUSPLUS_AFLPLUSPLUS_OTHER_HIERARFLOW_ROUTINES_HPP
+
+#include "fuzzuf/algorithms/afl/afl_other_hierarflow_routines.hpp"
+#include "fuzzuf/algorithms/aflplusplus/aflplusplus_state.hpp"
+#include "fuzzuf/algorithms/aflplusplus/aflplusplus_testcase.hpp"
+#include "fuzzuf/utils/common.hpp"
+
+namespace fuzzuf::algorithm::afl::routine::other {
+
+using AFLplusplusState = aflplusplus::AFLplusplusState;
+using AFLplusplusTestcase = aflplusplus::AFLplusplusTestcase;
+
+// explicit specialization
+template <>
+AFLMidCalleeRef<AFLplusplusState>
+ApplyDetMutsTemplate<AFLplusplusState>::operator()(
+    std::shared_ptr<AFLplusplusTestcase> testcase);
+
+// explicit specialization
+template <>
+AFLMidCalleeRef<AFLplusplusState>
+AbandonEntryTemplate<AFLplusplusState>::operator()(
+    std::shared_ptr<AFLplusplusTestcase> testcase);
+
+// explicit specialization
+template <>
+utils::NullableRef<hierarflow::HierarFlowCallee<void(void)>>
+SelectSeedTemplate<AFLplusplusState>::operator()(void);
+
+void CreateAliasTable(AFLplusplusState& state);
+
+double ComputeWeight(const AFLplusplusState& state,
+                     const AFLplusplusTestcase& testcase,
+                     const double& avg_exec_us, const double& avg_bitmap_size,
+                     const double& avg_top_size);
+
+}  // namespace fuzzuf::algorithm::afl::routine::other
+#endif

--- a/include/fuzzuf/algorithms/aflplusplus/aflplusplus_other_hierarflow_routines.hpp
+++ b/include/fuzzuf/algorithms/aflplusplus/aflplusplus_other_hierarflow_routines.hpp
@@ -47,6 +47,8 @@ SelectSeedTemplate<AFLplusplusState>::operator()(void);
 
 void CreateAliasTable(AFLplusplusState& state);
 
+void ComputeWeightVector(AFLplusplusState& state, std::vector<double>& vw);
+
 double ComputeWeight(const AFLplusplusState& state,
                      const AFLplusplusTestcase& testcase,
                      const double& avg_exec_us, const double& avg_bitmap_size,

--- a/include/fuzzuf/algorithms/aflplusplus/aflplusplus_setting.hpp
+++ b/include/fuzzuf/algorithms/aflplusplus/aflplusplus_setting.hpp
@@ -1,0 +1,42 @@
+/*
+ * fuzzuf
+ * Copyright (C) 2022 Ricerca Security
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see http://www.gnu.org/licenses/.
+ */
+#ifndef FUZZUF_INCLUDE_ALGORITHM_AFLPLUSPLUS_AFLPLUSPLUS_SETTING_HPP
+#define FUZZUF_INCLUDE_ALGORITHM_AFLPLUSPLUS_AFLPLUSPLUS_SETTING_HPP
+
+#include "fuzzuf/algorithms/aflfast/aflfast_setting.hpp"
+
+namespace fuzzuf::algorithm::aflplusplus {
+
+struct AFLplusplusSetting : public afl::AFLSetting {
+  explicit AFLplusplusSetting(const std::vector<std::string>& argv,
+                              const std::string& in_dir,
+                              const std::string& out_dir, u32 exec_timelimit_ms,
+                              u64 exec_memlimit, bool forksrv, bool dumb_mode,
+                              int cpuid_to_bind,
+                              const aflfast::option::Schedule schedule,
+                              std::string& schedule_string);
+
+  ~AFLplusplusSetting();
+
+  const aflfast::option::Schedule schedule = aflfast::option::FAST;
+  std::string schedule_string = "fast";
+};
+
+}  // namespace fuzzuf::algorithm::aflplusplus
+
+#endif

--- a/include/fuzzuf/algorithms/aflplusplus/aflplusplus_state.hpp
+++ b/include/fuzzuf/algorithms/aflplusplus/aflplusplus_state.hpp
@@ -1,0 +1,64 @@
+/*
+ * fuzzuf
+ * Copyright (C) 2022 Ricerca Security
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see http://www.gnu.org/licenses/.
+ */
+#ifndef FUZZUF_INCLUDE_ALGORITHM_AFLPLUSPLUS_AFLPLUSPLUS_STATE_HPP
+#define FUZZUF_INCLUDE_ALGORITHM_AFLPLUSPLUS_AFLPLUSPLUS_STATE_HPP
+
+#include <memory>
+
+#include "fuzzuf/algorithms/afl/afl_state.hpp"
+#include "fuzzuf/algorithms/aflplusplus/aflplusplus_setting.hpp"
+#include "fuzzuf/algorithms/aflplusplus/aflplusplus_testcase.hpp"
+#include "fuzzuf/executor/afl_executor_interface.hpp"
+#include "fuzzuf/feedback/exit_status_feedback.hpp"
+#include "fuzzuf/feedback/inplace_memory_feedback.hpp"
+#include "fuzzuf/optimizer/optimizer.hpp"
+#include "fuzzuf/utils/random.hpp"
+
+#define N_FUZZ_SIZE (1 << 21)
+
+namespace fuzzuf::algorithm::aflplusplus {
+
+using fuzzuf::utils::random::WalkerDiscreteDistribution;
+
+struct AFLplusplusState : public afl::AFLStateTemplate<AFLplusplusTestcase> {
+  explicit AFLplusplusState(
+      std::shared_ptr<const AFLplusplusSetting> setting,
+      std::shared_ptr<executor::AFLExecutorInterface> executor,
+      std::unique_ptr<optimizer::Optimizer<u32>> &&mutop_optimizer);
+
+  std::shared_ptr<AFLplusplusTestcase> AddToQueue(const std::string &fn,
+                                                  const u8 *buf, u32 len,
+                                                  bool passed_det) override;
+  void UpdateBitmapScoreWithRawTrace(AFLplusplusTestcase &testcase,
+                                     const u8 *trace_bits,
+                                     u32 map_size) override;
+  bool SaveIfInteresting(const u8 *buf, u32 len,
+                         feedback::InplaceMemoryFeedback &inp_feed,
+                         feedback::ExitStatusFeedback &exit_status) override;
+  u32 DoCalcScore(AFLplusplusTestcase &testcase) override;
+  void ShowStats(void) override;
+
+  std::shared_ptr<const AFLplusplusSetting> setting;
+  std::shared_ptr<u32[]> n_fuzz;
+
+  u32 prev_queued_items;
+  std::unique_ptr<WalkerDiscreteDistribution<double>> alias_probability;
+};
+
+}  // namespace fuzzuf::algorithm::aflplusplus
+#endif

--- a/include/fuzzuf/algorithms/aflplusplus/aflplusplus_testcase.hpp
+++ b/include/fuzzuf/algorithms/aflplusplus/aflplusplus_testcase.hpp
@@ -1,0 +1,40 @@
+/*
+ * fuzzuf
+ * Copyright (C) 2022 Ricerca Security
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see http://www.gnu.org/licenses/.
+ */
+#ifndef FUZZUF_INCLUDE_ALGORITHM_AFLPLUSPLUS_AFLPLUSPLUS_TESTCASE_HPP
+#define FUZZUF_INCLUDE_ALGORITHM_AFLPLUSPLUS_AFLPLUSPLUS_TESTCASE_HPP
+
+#include <bitset>
+#include <memory>
+
+#include "fuzzuf/algorithms/aflfast/aflfast_testcase.hpp"
+#include "fuzzuf/algorithms/aflplusplus/aflplusplus_option.hpp"
+#include "fuzzuf/exec_input/on_disk_exec_input.hpp"
+
+namespace fuzzuf::algorithm::aflplusplus {
+
+struct AFLplusplusTestcase : public afl::AFLTestcase {
+  using Tag = option::AFLplusplusTag;
+
+  AFLplusplusTestcase(std::shared_ptr<exec_input::OnDiskExecInput> input);
+  ~AFLplusplusTestcase();
+
+  u64 n_fuzz_entry; /* offset in n_fuzz */
+};
+
+}  // namespace fuzzuf::algorithm::aflplusplus
+#endif

--- a/include/fuzzuf/cli/fuzzer/aflplusplus/build_aflplusplus_fuzzer_from_args.hpp
+++ b/include/fuzzuf/cli/fuzzer/aflplusplus/build_aflplusplus_fuzzer_from_args.hpp
@@ -1,0 +1,269 @@
+/*
+ * fuzzuf
+ * Copyright (C) 2022 Ricerca Security
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see http://www.gnu.org/licenses/.
+ */
+
+#ifndef FUZZUF_INCLUDE_CLI_FUZZER_AFLPLUSPLUS_BUILD_AFLPLUSPLUS_FROM_ARGS_HPP
+#define FUZZUF_INCLUDE_CLI_FUZZER_AFLPLUSPLUS_BUILD_AFLPLUSPLUS_FROM_ARGS_HPP
+
+#include "fuzzuf/algorithms/afl/afl_havoc_case_distrib.hpp"
+#include "fuzzuf/algorithms/aflfast/aflfast_option.hpp"
+#include "fuzzuf/algorithms/aflplusplus/aflplusplus_option.hpp"
+#include "fuzzuf/algorithms/aflplusplus/aflplusplus_other_hierarflow_routines.hpp"
+#include "fuzzuf/algorithms/aflplusplus/aflplusplus_setting.hpp"
+#include "fuzzuf/algorithms/aflplusplus/aflplusplus_state.hpp"
+#include "fuzzuf/cli/fuzzer_args.hpp"
+#include "fuzzuf/cli/global_fuzzer_options.hpp"
+#include "fuzzuf/cli/put_args.hpp"
+#include "fuzzuf/exceptions.hpp"
+#include "fuzzuf/executor/native_linux_executor.hpp"
+#include "fuzzuf/executor/qemu_executor.hpp"
+#include "fuzzuf/optimizer/optimizer.hpp"
+#include "fuzzuf/utils/optparser.hpp"
+#include "fuzzuf/utils/workspace.hpp"
+#ifdef __aarch64__
+#include "fuzzuf/executor/coresight_executor.hpp"
+#endif
+#include <boost/program_options.hpp>
+
+namespace fuzzuf::cli::fuzzer::aflplusplus {
+
+namespace po = boost::program_options;
+
+struct AFLplusplusFuzzerOptions {
+  bool forksrv;                        // Optional
+  std::vector<std::string> dict_file;  // Optional
+  bool frida_mode;                     // Optional
+  std::string schedule;                // Optional
+
+  // Default values
+  AFLplusplusFuzzerOptions()
+      : forksrv(true), frida_mode(false), schedule("fast"){};
+};
+
+// Fuzzer specific help
+// TODO: Provide better help message
+static void usage(po::options_description &desc) {
+  std::cout << "Help:" << std::endl;
+  std::cout << desc << std::endl;
+  exit(1);
+}
+
+// Used only for CLI
+template <class TFuzzer, class TAFLFuzzer, class TExecutor>
+std::unique_ptr<TFuzzer> BuildAFLplusplusFuzzerFromArgs(
+    FuzzerArgs &fuzzer_args, GlobalFuzzerOptions &global_options) {
+  po::positional_options_description pargs_desc;
+  pargs_desc.add("fuzzer", 1);
+  pargs_desc.add("pargs", -1);
+
+  AFLplusplusFuzzerOptions aflplusplus_options;
+
+  po::options_description fuzzer_desc("AFLplusplus options");
+  std::vector<std::string> pargs;
+  fuzzer_desc.add_options()(
+      "forksrv",
+      po::value<bool>(&aflplusplus_options.forksrv)
+          ->default_value(aflplusplus_options.forksrv),
+      "Enable/disable fork server mode. default is true.")(
+      "dict_file,x",
+      po::value<std::vector<std::string>>(&aflplusplus_options.dict_file)
+          ->composing(),
+      "Load additional dictionary file.")
+      // If you want to add fuzzer specific options, add options here
+      ("pargs", po::value<std::vector<std::string>>(&pargs),
+       "Specify PUT and args for PUT.")(
+          "frida",
+          po::value<bool>(&aflplusplus_options.frida_mode)
+              ->default_value(aflplusplus_options.frida_mode),
+          "Enable/disable frida mode. Default to false.")(
+          "det,D",
+          "Do not skip deterministic stages if specified (AFLplusplus skips "
+          "them by default)")(
+          "schedule,p",
+          po::value<std::string>(&aflplusplus_options.schedule)
+              ->default_value(aflplusplus_options.schedule),
+          "Power schedule to use. Available values are:\n"
+          "fast (default), coe, explore, lin, quad, exploit");
+
+  po::variables_map vm;
+  po::store(
+      po::command_line_parser(fuzzer_args.argc, fuzzer_args.argv)
+          .options(fuzzer_args.global_options_description.add(fuzzer_desc))
+          .positional(pargs_desc)
+          .run(),
+      vm);
+  po::notify(vm);
+
+  if (global_options.help) {
+    fuzzuf::cli::fuzzer::aflplusplus::usage(
+        fuzzer_args.global_options_description);
+  }
+
+  using fuzzuf::algorithm::afl::option::GetMemLimit;
+  using fuzzuf::algorithm::aflplusplus::option::AFLplusplusTag;
+
+  u32 mem_limit =
+      global_options.exec_memlimit.value_or(GetMemLimit<AFLplusplusTag>());
+  if (aflplusplus_options.frida_mode) {
+    setenv("__AFL_DEFER_FORKSRV", "1", 1);
+    fs::path frida_bin =
+        fs::path(fuzzer_args.argv[0]).parent_path() / "afl-frida-trace.so";
+    setenv("LD_PRELOAD", frida_bin.c_str(), 1);
+
+    if (mem_limit > 0) {
+      struct stat statbuf;
+      if ((stat(frida_bin.c_str(), &statbuf)) == -1) {
+        std::cerr
+            << cLRD << "[-] File afl-frida-trace.so not found\n"
+            << "    Build one first with cmake where -DENABLE_FRIDA_TRACE=1"
+            << cRST << std::endl;
+      }
+      // Need to add the size of the library
+      mem_limit += statbuf.st_size;
+    }
+  }
+
+  PutArgs put(pargs);
+  try {
+    put.Check();
+  } catch (const exceptions::cli_error &e) {
+    std::cerr << "[!] " << e.what() << std::endl;
+    std::cerr << "\tat " << e.file << ":" << e.line << std::endl;
+    fuzzuf::cli::fuzzer::aflplusplus::usage(
+        fuzzer_args.global_options_description);
+  }
+
+  // Trace level log
+  DEBUG("[*] PUT: put = [");
+  for (auto v : put.Args()) {
+    DEBUG("\t\"%s\",", v.c_str());
+  }
+  DEBUG("    ]");
+
+  using fuzzuf::algorithm::afl::option::GetExecTimeout;
+  using fuzzuf::algorithm::aflplusplus::AFLplusplusSetting;
+
+  // Create AFLplusplusSetting
+
+  fuzzuf::algorithm::aflfast::option::Schedule schedule;
+  if (!aflplusplus_options.schedule.compare("fast")) {
+    schedule = fuzzuf::algorithm::aflfast::option::FAST;
+  } else if (!aflplusplus_options.schedule.compare("coe")) {
+    schedule = fuzzuf::algorithm::aflfast::option::COE;
+  } else if (!aflplusplus_options.schedule.compare("explore")) {
+    schedule = fuzzuf::algorithm::aflfast::option::EXPLORE;
+  } else if (!aflplusplus_options.schedule.compare("lin")) {
+    schedule = fuzzuf::algorithm::aflfast::option::LIN;
+  } else if (!aflplusplus_options.schedule.compare("quad")) {
+    schedule = fuzzuf::algorithm::aflfast::option::QUAD;
+  } else if (!aflplusplus_options.schedule.compare("exploit")) {
+    schedule = fuzzuf::algorithm::aflfast::option::EXPLOIT;
+  } else {
+    std::cout << cLRD "[-] Unknown power schedule!"
+              << "(" << aflplusplus_options.schedule << ")" cRST << std::endl;
+    std::exit(1);
+  }
+
+  auto setting = std::make_shared<const AFLplusplusSetting>(
+      put.Args(), global_options.in_dir, global_options.out_dir,
+      global_options.exec_timelimit_ms.value_or(
+          GetExecTimeout<AFLplusplusTag>()),
+      mem_limit, aflplusplus_options.forksrv,
+      /* dumb_mode */ false,  // FIXME: add dumb_mode
+      fuzzuf::utils::CPUID_BIND_WHICHEVER, schedule,
+      aflplusplus_options.schedule);
+
+  // NativeLinuxExecutor needs the directory specified by "out_dir" to be
+  // already set up so we need to create the directory first, and then
+  // initialize Executor
+  fuzzuf::utils::SetupDirs(setting->out_dir.string());
+
+  using fuzzuf::algorithm::afl::option::GetDefaultOutfile;
+  using fuzzuf::algorithm::afl::option::GetMapSize;
+  using fuzzuf::cli::ExecutorKind;
+
+  std::shared_ptr<TExecutor> executor;
+  switch (global_options.executor) {
+    case ExecutorKind::NATIVE: {
+      auto nle = std::make_shared<fuzzuf::executor::NativeLinuxExecutor>(
+          setting->argv, setting->exec_timelimit_ms, setting->exec_memlimit,
+          setting->forksrv,
+          setting->out_dir / GetDefaultOutfile<AFLplusplusTag>(),
+          GetMapSize<AFLplusplusTag>(),  // afl_shm_size
+          0                              // bb_shm_size
+      );
+      executor = std::make_shared<TExecutor>(std::move(nle));
+      break;
+    }
+
+    case ExecutorKind::QEMU: {
+      // NOTE: Assuming GetMapSize<AFLplusplusTag>() ==
+      // QEMUExecutor::QEMU_SHM_SIZE
+      auto qe = std::make_shared<fuzzuf::executor::QEMUExecutor>(
+          global_options.proxy_path.value(), setting->argv,
+          setting->exec_timelimit_ms, setting->exec_memlimit, setting->forksrv,
+          setting->out_dir / GetDefaultOutfile<AFLplusplusTag>());
+      executor = std::make_shared<TExecutor>(std::move(qe));
+      break;
+    }
+
+#ifdef __aarch64__
+    case ExecutorKind::CORESIGHT: {
+      auto cse = std::make_shared<fuzzuf::executor::CoreSightExecutor>(
+          global_options.proxy_path.value(), setting->argv,
+          setting->exec_timelimit_ms, setting->exec_memlimit, setting->forksrv,
+          setting->out_dir / GetDefaultOutfile<AFLplusplusTag>(),
+          GetMapSize<AFLplusplusTag>()  // afl_shm_size
+      );
+      executor = std::make_shared<TExecutor>(std::move(cse));
+      break;
+    }
+#endif
+
+    default:
+      EXIT("Unsupported executor: '%s'", global_options.executor.c_str());
+  }
+
+  auto mutop_optimizer = std::unique_ptr<optimizer::Optimizer<u32>>(
+      new algorithm::afl::AFLHavocCaseDistrib());
+
+  // Create AFLplusplusState
+  using fuzzuf::algorithm::aflplusplus::AFLplusplusState;
+  auto state = std::make_unique<AFLplusplusState>(setting, executor,
+                                                  std::move(mutop_optimizer));
+
+  state->skip_deterministic = !vm.count("det");
+
+  // Load dictionary
+  for (const auto &d : aflplusplus_options.dict_file) {
+    using fuzzuf::algorithm::afl::dictionary::AFLDictData;
+
+    const std::function<void(std::string &&)> f = [](std::string s) {
+      ERROR("Dictionary error: %s", s.c_str());
+    };
+
+    fuzzuf::algorithm::afl::dictionary::load(d, state->extras, false, f);
+  }
+  fuzzuf::algorithm::afl::dictionary::SortDictByLength(state->extras);
+
+  return std::unique_ptr<TFuzzer>(
+      dynamic_cast<TFuzzer *>(new TAFLFuzzer(std::move(state))));
+}
+
+}  // namespace fuzzuf::cli::fuzzer::aflplusplus
+
+#endif

--- a/include/fuzzuf/cli/fuzzer/aflplusplus/build_aflplusplus_fuzzer_from_args.hpp
+++ b/include/fuzzuf/cli/fuzzer/aflplusplus/build_aflplusplus_fuzzer_from_args.hpp
@@ -21,6 +21,7 @@
 
 #include "fuzzuf/algorithms/afl/afl_havoc_case_distrib.hpp"
 #include "fuzzuf/algorithms/aflfast/aflfast_option.hpp"
+#include "fuzzuf/algorithms/aflplusplus/aflplusplus_havoc.hpp"
 #include "fuzzuf/algorithms/aflplusplus/aflplusplus_option.hpp"
 #include "fuzzuf/algorithms/aflplusplus/aflplusplus_other_hierarflow_routines.hpp"
 #include "fuzzuf/algorithms/aflplusplus/aflplusplus_setting.hpp"
@@ -254,7 +255,7 @@ std::unique_ptr<TFuzzer> BuildAFLplusplusFuzzerFromArgs(
   }
 
   auto mutop_optimizer = std::unique_ptr<optimizer::Optimizer<u32>>(
-      new algorithm::afl::AFLHavocCaseDistrib());
+      new algorithm::aflplusplus::havoc::AFLplusplusHavocCaseDistrib());
 
   // Create AFLplusplusState
   using fuzzuf::algorithm::aflplusplus::AFLplusplusState;

--- a/include/fuzzuf/cli/fuzzer/aflplusplus/build_aflplusplus_fuzzer_from_args.hpp
+++ b/include/fuzzuf/cli/fuzzer/aflplusplus/build_aflplusplus_fuzzer_from_args.hpp
@@ -29,6 +29,7 @@
 #include "fuzzuf/cli/global_fuzzer_options.hpp"
 #include "fuzzuf/cli/put_args.hpp"
 #include "fuzzuf/exceptions.hpp"
+#include "fuzzuf/executor/linux_fork_server_executor.hpp"
 #include "fuzzuf/executor/native_linux_executor.hpp"
 #include "fuzzuf/executor/qemu_executor.hpp"
 #include "fuzzuf/optimizer/optimizer.hpp"
@@ -207,6 +208,20 @@ std::unique_ptr<TFuzzer> BuildAFLplusplusFuzzerFromArgs(
           0                              // bb_shm_size
       );
       executor = std::make_shared<TExecutor>(std::move(nle));
+      break;
+    }
+
+    case ExecutorKind::FORKSERVER: {
+      auto lfe = std::make_shared<fuzzuf::executor::LinuxForkServerExecutor>(
+          fuzzuf::executor::LinuxForkServerExecutorParameters()
+              .set_argv(setting->argv)
+              .set_exec_timelimit_ms(setting->exec_timelimit_ms)
+              .set_exec_memlimit(setting->exec_memlimit)
+              .set_path_to_write_input(setting->out_dir /
+                                       GetDefaultOutfile<AFLplusplusTag>())
+              .set_afl_shm_size(GetMapSize<AFLplusplusTag>())  // afl_shm_size
+              .move());
+      executor = std::make_shared<TExecutor>(std::move(lfe));
       break;
     }
 

--- a/test/algorithms/aflplusplus/CMakeLists.txt
+++ b/test/algorithms/aflplusplus/CMakeLists.txt
@@ -1,0 +1,66 @@
+add_executable( test-aflplusplus-loop loop.cpp )
+target_link_libraries(
+  test-aflplusplus-loop
+  test-common
+  fuzzuf_core
+  fuzzuf-cli-lib
+  ${FUZZUF_LIBRARIES}
+  Boost::unit_test_framework
+)
+target_include_directories(
+  test-aflplusplus-loop
+  PRIVATE
+  ${FUZZUF_INCLUDE_DIRS}
+  ${CMAKE_SOURCE_DIR}/test/common
+)
+set_target_properties(
+  test-aflplusplus-loop
+  PROPERTIES COMPILE_FLAGS "${ADDITIONAL_COMPILE_FLAGS_STR}"
+)
+set_target_properties(
+  test-aflplusplus-loop
+  PROPERTIES LINK_FLAGS "${ADDITIONAL_LINK_FLAGS_STR}"
+)
+if( ENABLE_CLANG_TIDY )
+  set_target_properties(
+    test-aflplusplus-loop
+    PROPERTIES
+    CXX_CLANG_TIDY "${CLANG_TIDY};${CLANG_TIDY_CONFIG_FOR_TEST}"
+  )
+endif()
+if( ENABLE_HEAVY_TEST )
+add_test( NAME "aflplusplus.loop" COMMAND test-aflplusplus-loop )
+endif()
+
+add_executable( test-aflplusplus-cli_parser cli_parser.cpp )
+target_link_libraries(
+  test-aflplusplus-cli_parser
+  test-common
+  fuzzuf_core
+  fuzzuf-cli-lib
+  ${FUZZUF_LIBRARIES}
+  Boost::unit_test_framework
+)
+target_include_directories(
+  test-aflplusplus-cli_parser
+  PRIVATE
+  ${FUZZUF_INCLUDE_DIRS}
+  ${CMAKE_SOURCE_DIR}/test/common
+)
+set_target_properties(
+  test-aflplusplus-cli_parser
+  PROPERTIES COMPILE_FLAGS "${ADDITIONAL_COMPILE_FLAGS_STR}"
+)
+set_target_properties(
+  test-aflplusplus-cli_parser
+  PROPERTIES LINK_FLAGS "${ADDITIONAL_LINK_FLAGS_STR}"
+)
+if( ENABLE_CLANG_TIDY )
+  set_target_properties(
+    test-aflplusplus-cli_parser
+    PROPERTIES
+    CXX_CLANG_TIDY "${CLANG_TIDY};${CLANG_TIDY_CONFIG_FOR_TEST}"
+  )
+endif()
+add_test( NAME "algorithms.aflplusplus.cli_parser" COMMAND test-aflplusplus-cli_parser )
+

--- a/test/algorithms/aflplusplus/CMakeLists.txt
+++ b/test/algorithms/aflplusplus/CMakeLists.txt
@@ -64,3 +64,35 @@ if( ENABLE_CLANG_TIDY )
 endif()
 add_test( NAME "algorithms.aflplusplus.cli_parser" COMMAND test-aflplusplus-cli_parser )
 
+add_executable( test-aflplusplus-compute_weight compute_weight.cpp )
+target_link_libraries(
+  test-aflplusplus-compute_weight
+  test-common
+  fuzzuf_core
+  fuzzuf-cli-lib
+  ${FUZZUF_LIBRARIES}
+  Boost::unit_test_framework
+)
+target_include_directories(
+  test-aflplusplus-compute_weight
+  PRIVATE
+  ${FUZZUF_INCLUDE_DIRS}
+  ${CMAKE_SOURCE_DIR}/test/common
+)
+set_target_properties(
+  test-aflplusplus-compute_weight
+  PROPERTIES COMPILE_FLAGS "${ADDITIONAL_COMPILE_FLAGS_STR}"
+)
+set_target_properties(
+  test-aflplusplus-compute_weight
+  PROPERTIES LINK_FLAGS "${ADDITIONAL_LINK_FLAGS_STR}"
+)
+if( ENABLE_CLANG_TIDY )
+  set_target_properties(
+    test-aflplusplus-compute_weight
+    PROPERTIES
+    CXX_CLANG_TIDY "${CLANG_TIDY};${CLANG_TIDY_CONFIG_FOR_TEST}"
+  )
+endif()
+add_test( NAME "algorithms.aflplusplus.compute_weight" COMMAND test-aflplusplus-compute_weight )
+

--- a/test/algorithms/aflplusplus/CMakeLists.txt
+++ b/test/algorithms/aflplusplus/CMakeLists.txt
@@ -96,3 +96,34 @@ if( ENABLE_CLANG_TIDY )
 endif()
 add_test( NAME "algorithms.aflplusplus.compute_weight" COMMAND test-aflplusplus-compute_weight )
 
+add_executable( test-aflplusplus-fast3_score fast3_score.cpp )
+target_link_libraries(
+  test-aflplusplus-fast3_score
+  test-common
+  fuzzuf_core
+  fuzzuf-cli-lib
+  ${FUZZUF_LIBRARIES}
+  Boost::unit_test_framework
+)
+target_include_directories(
+  test-aflplusplus-fast3_score
+  PRIVATE
+  ${FUZZUF_INCLUDE_DIRS}
+  ${CMAKE_SOURCE_DIR}/test/common
+)
+set_target_properties(
+  test-aflplusplus-fast3_score
+  PROPERTIES COMPILE_FLAGS "${ADDITIONAL_COMPILE_FLAGS_STR}"
+)
+set_target_properties(
+  test-aflplusplus-fast3_score
+  PROPERTIES LINK_FLAGS "${ADDITIONAL_LINK_FLAGS_STR}"
+)
+if( ENABLE_CLANG_TIDY )
+  set_target_properties(
+    test-aflplusplus-fast3_score
+    PROPERTIES
+    CXX_CLANG_TIDY "${CLANG_TIDY};${CLANG_TIDY_CONFIG_FOR_TEST}"
+  )
+endif()
+add_test( NAME "algorithms.aflplusplus.fast3_score" COMMAND test-aflplusplus-fast3_score )

--- a/test/algorithms/aflplusplus/cli_parser.cpp
+++ b/test/algorithms/aflplusplus/cli_parser.cpp
@@ -1,0 +1,72 @@
+/*
+ * fuzzuf
+ * Copyright (C) 2021 Ricerca Security
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see http://www.gnu.org/licenses/.
+ */
+#include "fuzzuf/algorithms/aflplusplus/aflplusplus_state.hpp"
+#define BOOST_TEST_MODULE algorithms.aflplusplus.cli_parser
+#define BOOST_TEST_DYN_LINK
+#include <array>
+#include <boost/test/unit_test.hpp>
+#include <iostream>
+
+#include "fuzzuf/cli/fuzzer/aflplusplus/build_aflplusplus_fuzzer_from_args.hpp"
+#include "fuzzuf/cli/global_args.hpp"
+#include "fuzzuf/cli/global_fuzzer_options.hpp"
+#include "fuzzuf/cli/parse_global_options_for_fuzzer.hpp"
+#include "fuzzuf/cli/stub/afl_fuzzer_stub.hpp"
+#include "fuzzuf/exceptions.hpp"
+#include "fuzzuf/logger/logger.hpp"
+#include "fuzzuf/utils/common.hpp"
+
+#define Argc(argv) (sizeof(argv) / sizeof(char *))
+
+BOOST_AUTO_TEST_CASE(BuildAFLplusplusByParsingGlobalOptionAndPUT) {
+  using AFLplusplusState = fuzzuf::algorithm::aflplusplus::AFLplusplusState;
+  using fuzzuf::executor::AFLExecutorInterface;
+  fuzzuf::cli::GlobalFuzzerOptions options;
+#pragma GCC diagnostic ignored "-Wwrite-strings"
+  // 本来はschedule用のオプションもテストされるべきだが、CLI側の改修が必要なので一旦放置
+  const char *argv[] = {
+      "fuzzuf", "aflplusplus",
+      // Global options
+      "--in_dir=chahz3ea4deRah4o", "--forksrv=false",
+      // PUT options.
+      // Because NativeLinuxExecutor throws error,
+      // we can't use a random value here.
+      "../put_binaries/command_wrapper",  // PUT
+      "oung6UgoQue1eiYu"                  // arguments
+  };
+  fuzzuf::cli::GlobalArgs args = {
+      .argc = Argc(argv),
+      .argv = argv,
+  };
+
+  // Parse global options and PUT, and build fuzzer
+  using fuzzuf::cli::fuzzer::aflplusplus::BuildAFLplusplusFuzzerFromArgs;
+
+  auto fuzzer_args = fuzzuf::cli::ParseGlobalOptionsForFuzzer(args, options);
+  auto fuzzer = BuildAFLplusplusFuzzerFromArgs<
+      fuzzuf::cli::AFLFuzzerStub<AFLplusplusState>,
+      fuzzuf::cli::AFLFuzzerStub<AFLplusplusState>, AFLExecutorInterface>(
+      fuzzer_args, options);
+
+  BOOST_CHECK_EQUAL(options.in_dir, "chahz3ea4deRah4o");
+
+  auto &state = *fuzzer->state;
+  BOOST_CHECK_EQUAL(state.setting->argv.size(), 2);
+  BOOST_CHECK_EQUAL(state.setting->argv[0], "../put_binaries/command_wrapper");
+  BOOST_CHECK_EQUAL(state.setting->argv[1], "oung6UgoQue1eiYu");
+}

--- a/test/algorithms/aflplusplus/compute_weight.cpp
+++ b/test/algorithms/aflplusplus/compute_weight.cpp
@@ -1,0 +1,83 @@
+/*
+ * fuzzuf
+ * Copyright (C) 2022 Ricerca Security
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see http://www.gnu.org/licenses/.
+ */
+#define BOOST_TEST_MODULE algorithms.aflplusplus.compute_weight
+#define BOOST_TEST_DYN_LINK
+#include <boost/test/tools/interface.hpp>
+#include <boost/test/unit_test.hpp>
+#include <random>
+
+#include "fuzzuf/algorithms/aflplusplus/aflplusplus_other_hierarflow_routines.hpp"
+#include "fuzzuf/algorithms/aflplusplus/aflplusplus_state.hpp"
+#include "fuzzuf/algorithms/aflplusplus/aflplusplus_testcase.hpp"
+#include "fuzzuf/cli/fuzzer/aflplusplus/build_aflplusplus_fuzzer_from_args.hpp"
+#include "fuzzuf/cli/global_args.hpp"
+#include "fuzzuf/cli/global_fuzzer_options.hpp"
+#include "fuzzuf/cli/parse_global_options_for_fuzzer.hpp"
+#include "fuzzuf/cli/stub/afl_fuzzer_stub.hpp"
+#include "fuzzuf/executor/afl_executor_interface.hpp"
+
+#define Argc(argv) (sizeof(argv) / sizeof(char *))
+
+BOOST_AUTO_TEST_CASE(ComputeWeightThenCompare) {
+  using AFLplusplusState = fuzzuf::algorithm::aflplusplus::AFLplusplusState;
+  using fuzzuf::executor::AFLExecutorInterface;
+  fuzzuf::cli::GlobalFuzzerOptions options;
+  // dummy argv
+  const char *argv[] = {"fuzzuf", "aflplusplus", "-i", "/dev/null",
+                        "--forksrv=false", "--", "/bin/ls"};
+
+  fuzzuf::cli::GlobalArgs args = {
+      .argc = Argc(argv),
+      .argv = argv,
+  };
+
+  // Parse global options and PUT, and build fuzzer
+  using fuzzuf::cli::fuzzer::aflplusplus::BuildAFLplusplusFuzzerFromArgs;
+
+  auto fuzzer_args = fuzzuf::cli::ParseGlobalOptionsForFuzzer(args, options);
+  auto fuzzer = BuildAFLplusplusFuzzerFromArgs<
+      fuzzuf::cli::AFLFuzzerStub<AFLplusplusState>,
+      fuzzuf::cli::AFLFuzzerStub<AFLplusplusState>, AFLExecutorInterface>(
+      fuzzer_args, options);
+
+  auto &state = *fuzzer->state;
+
+  const std::size_t count = 10;
+  std::random_device gen;
+  std::mt19937_64 engine(gen());
+
+  // add dummy testcases
+  for (std::size_t i = 0; i < count; ++i) {
+    std::string devnull("/dev/null");
+    const u8 buf[] = { 'f', 'u', 'z', 'z' };
+    u32 len = sizeof(buf);
+    auto tc = state.AddToQueue(devnull, buf, len, false);
+    // just fill the required elems with random values
+    tc->exec_us = engine();
+    tc->bitmap_size = static_cast<u32>(engine());
+    tc->tc_ref = static_cast<u32>(engine());
+  }
+  BOOST_CHECK_EQUAL(count, state.case_queue.size());
+
+  std::vector<double> vw1, vw2;
+  fuzzuf::algorithm::afl::routine::other::ComputeWeightVector(state, vw1);
+  fuzzuf::algorithm::afl::routine::other::ComputeWeightVector(state, vw2);
+
+  BOOST_CHECK_EQUAL(vw1.size(), vw2.size());
+  BOOST_TEST((vw1 == vw2), boost::test_tools::per_element());
+}

--- a/test/algorithms/aflplusplus/fast3_score.cpp
+++ b/test/algorithms/aflplusplus/fast3_score.cpp
@@ -1,0 +1,94 @@
+/*
+ * fuzzuf
+ * Copyright (C) 2022 Ricerca Security
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see http://www.gnu.org/licenses/.
+ */
+#include "fuzzuf/algorithms/aflfast/aflfast_option.hpp"
+#define BOOST_TEST_MODULE algorithms.aflplusplus.fast3_score
+#define BOOST_TEST_DYN_LINK
+#include <boost/test/tools/interface.hpp>
+#include <boost/test/unit_test.hpp>
+
+#include "fuzzuf/algorithms/aflplusplus/aflplusplus_other_hierarflow_routines.hpp"
+#include "fuzzuf/algorithms/aflplusplus/aflplusplus_state.hpp"
+#include "fuzzuf/algorithms/aflplusplus/aflplusplus_testcase.hpp"
+#include "fuzzuf/cli/fuzzer/aflplusplus/build_aflplusplus_fuzzer_from_args.hpp"
+#include "fuzzuf/cli/global_args.hpp"
+#include "fuzzuf/cli/global_fuzzer_options.hpp"
+#include "fuzzuf/cli/parse_global_options_for_fuzzer.hpp"
+#include "fuzzuf/cli/stub/afl_fuzzer_stub.hpp"
+#include "fuzzuf/executor/afl_executor_interface.hpp"
+
+#define Argc(argv) (sizeof(argv) / sizeof(char *))
+
+BOOST_AUTO_TEST_CASE(CalcScoresForEachPowerScheds) {
+  using AFLplusplusState = fuzzuf::algorithm::aflplusplus::AFLplusplusState;
+  using fuzzuf::executor::AFLExecutorInterface;
+  fuzzuf::cli::GlobalFuzzerOptions options;
+  // dummy argv
+  const char *argv[] = {"fuzzuf", "aflplusplus",     "-i", "/dev/null", "-p",
+                        "fast",   "--forksrv=false", "--", "/bin/ls"};
+  std::vector<std::pair<const char *, u32>> schedules = {
+      {"fast", 60}, {"coe", 0},    {"explore", 30},
+      {"lin", 35},  {"quad", 705}, {"exploit", 960},
+  };
+
+  for (auto &sched : schedules) {
+    // ugly, but it works
+    argv[5] = sched.first;
+    fuzzuf::cli::GlobalArgs args = {
+        .argc = Argc(argv),
+        .argv = argv,
+    };
+    // Parse global options and PUT, and build fuzzer
+    using fuzzuf::cli::fuzzer::aflplusplus::BuildAFLplusplusFuzzerFromArgs;
+
+    auto fuzzer_args = fuzzuf::cli::ParseGlobalOptionsForFuzzer(args, options);
+    auto fuzzer = BuildAFLplusplusFuzzerFromArgs<
+        fuzzuf::cli::AFLFuzzerStub<AFLplusplusState>,
+        fuzzuf::cli::AFLFuzzerStub<AFLplusplusState>, AFLExecutorInterface>(
+        fuzzer_args, options);
+
+    auto &state = *fuzzer->state;
+
+    // set dummy state member variables (to avoid div by zero, and fix
+    // perf_score to 10*3 = 30) in this test, perf_score will be fixed to 30
+    state.total_cal_cycles = 1;
+    state.total_bitmap_entries = 1;
+
+    // add a dummy testcase 1
+    // set up member variables to make return values different by each power
+    // schedule
+    std::string devnull("/dev/null");
+    const u8 buf[] = {'f', 'u', 'z', 'z'};
+    u32 len = sizeof(buf);
+    auto tc1 = state.AddToQueue(devnull, buf, len, false);
+    tc1->exec_us = 1;
+    tc1->bitmap_size = 1;
+    tc1->fuzz_level = 20;
+    tc1->n_fuzz_entry = 0;
+    tc1->favored = false;
+    state.n_fuzz[tc1->n_fuzz_entry] = 16;  // log2(16) = 4
+
+    // add a dummy testcase 2 (unused for score calculation)
+    auto tc2 = state.AddToQueue(devnull, buf, len, false);
+    tc2->n_fuzz_entry = 1;
+    state.n_fuzz[tc2->n_fuzz_entry] = 1;  // log2(1) = 0
+
+    u32 score = state.DoCalcScore(*tc1);
+    std::cout << sched.first << ": " << score << std::endl;
+    BOOST_CHECK_EQUAL(score, sched.second);
+  }
+}

--- a/test/algorithms/aflplusplus/loop.cpp
+++ b/test/algorithms/aflplusplus/loop.cpp
@@ -1,0 +1,87 @@
+/*
+ * fuzzuf
+ * Copyright (C) 2021 Ricerca Security
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see http://www.gnu.org/licenses/.
+ */
+#define BOOST_TEST_MODULE aflplusplus.loop
+#define BOOST_TEST_DYN_LINK
+#include <boost/scope_exit.hpp>
+#include <boost/test/unit_test.hpp>
+#include <iostream>
+#include <random>
+
+#include "fuzzuf/cli/create_fuzzer_instance_from_argv.hpp"
+#include "fuzzuf/utils/filesystem.hpp"
+#include "fuzzuf/utils/workspace.hpp"
+#include "move_to_program_location.hpp"
+
+// to test both fork server mode and non fork server mode, we specify forksrv
+// via an argument
+static void AFLLoop(bool forksrv) {
+  // cd $(dirname $0)
+  MoveToProgramLocation();
+
+  // Create root directory
+  std::string root_dir_template("/tmp/fuzzuf_test.XXXXXX");
+  const auto raw_dirname = mkdtemp(root_dir_template.data());
+  if (!raw_dirname) throw -1;
+  BOOST_CHECK(raw_dirname != nullptr);
+
+  auto root_dir = fs::path(raw_dirname);
+  BOOST_SCOPE_EXIT(&root_dir) {
+    // Executed on this test exit
+    fs::remove_all(root_dir);
+  }
+  BOOST_SCOPE_EXIT_END
+
+  // Create input file
+  auto put_dir = fs::path("../../put_binaries/libjpeg");
+  auto input_dir = put_dir / "seeds";
+  auto output_dir = root_dir / "output";
+
+  auto input_dir_opt = "--in_dir=" + input_dir.string();
+  auto output_dir_opt = "--out_dir=" + output_dir.string();
+  const char *forksrv_opt = forksrv ? "--forksrv=1" : "--forksrv=0";
+
+  const char *argv[] = {"fuzzuf",
+                        "aflplusplus",
+                        input_dir_opt.c_str(),
+                        output_dir_opt.c_str(),
+                        forksrv_opt,
+                        "../../put_binaries/libjpeg/libjpeg_turbo_fuzzer",
+                        "@@",
+                        nullptr};
+  int argc = static_cast<int>(sizeof(argv) / sizeof(const char *)) -
+             1;  // subtract 1 for nullptr
+  auto fuzzer = fuzzuf::cli::CreateFuzzerInstanceFromArgv(argc, argv);
+
+  for (int i = 0; i < 1; i++) {
+    std::cout << "the " << i << "-th iteration starts" << std::endl;
+    fuzzer->OneLoop();
+  }
+}
+
+BOOST_AUTO_TEST_CASE(AFLLoopNonForkMode) {
+  // 出力を入れないと、複数テストケースある場合、切れ目がどこかが分からず、どっちが失敗しているか分からない事に気づいた
+  std::cout << "[*] AFLLoopNonForkMode started\n";
+  AFLLoop(false);
+  std::cout << "[*] AFLLoopNonForkMode ended\n";
+}
+
+BOOST_AUTO_TEST_CASE(AFLLoopForkMode) {
+  std::cout << "[*] AFLLoopForkMode started\n";
+  AFLLoop(true);
+  std::cout << "[*] AFLLoopForkMode ended\n";
+}

--- a/test/mutator/CMakeLists.txt
+++ b/test/mutator/CMakeLists.txt
@@ -62,6 +62,8 @@ if( ENABLE_CLANG_TIDY )
 endif()
 add_test( NAME "mutator.havoc" COMMAND test-mutator-havoc )
 
+list( FIND ALGORITHMS "aflplusplus" AFLPLUSPLUS_INDEX )
+if( NOT "${AFLPLUSPLUS_INDEX}" EQUAL "-1" )
 add_executable( test-mutator-more-havoc more_havoc.cpp )
 target_link_libraries(
         test-mutator-more-havoc
@@ -93,3 +95,4 @@ if( ENABLE_CLANG_TIDY )
   )
 endif()
 add_test( NAME "mutator.more_havoc" COMMAND test-mutator-more-havoc )
+endif()

--- a/test/mutator/CMakeLists.txt
+++ b/test/mutator/CMakeLists.txt
@@ -61,3 +61,35 @@ if( ENABLE_CLANG_TIDY )
   )
 endif()
 add_test( NAME "mutator.havoc" COMMAND test-mutator-havoc )
+
+add_executable( test-mutator-more-havoc more_havoc.cpp )
+target_link_libraries(
+        test-mutator-more-havoc
+        test-common
+        fuzzuf_core
+	fuzzuf_core_afl_common
+        ${FUZZUF_LIBRARIES}
+        Boost::unit_test_framework
+)
+target_include_directories(
+        test-mutator-more-havoc
+        PRIVATE
+        ${FUZZUF_INCLUDE_DIRS}
+        ${CMAKE_SOURCE_DIR}/test/common
+)
+set_target_properties(
+  test-mutator-more-havoc
+  PROPERTIES COMPILE_FLAGS "${ADDITIONAL_COMPILE_FLAGS_STR}"
+)
+set_target_properties(
+  test-mutator-more-havoc
+  PROPERTIES LINK_FLAGS "${ADDITIONAL_LINK_FLAGS_STR}"
+)
+if( ENABLE_CLANG_TIDY )
+  set_target_properties(
+    test-mutator-more-havoc
+    PROPERTIES
+    CXX_CLANG_TIDY "${CLANG_TIDY};${CLANG_TIDY_CONFIG_FOR_TEST}"
+  )
+endif()
+add_test( NAME "mutator.more_havoc" COMMAND test-mutator-more-havoc )

--- a/test/mutator/more_havoc.cpp
+++ b/test/mutator/more_havoc.cpp
@@ -1,0 +1,118 @@
+/*
+ * fuzzuf
+ * Copyright (C) 2022 Ricerca Security
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see http://www.gnu.org/licenses/.
+ */
+#include "fuzzuf/mutator/havoc_case.hpp"
+#define BOOST_TEST_MODULE mutator.more_havoc
+#define BOOST_TEST_DYN_LINK
+#include <boost/test/unit_test.hpp>
+#include <string>
+
+#include "fuzzuf/algorithms/aflplusplus/aflplusplus_havoc.hpp"
+#include "fuzzuf/exec_input/exec_input_set.hpp"
+#include "fuzzuf/exec_input/on_memory_exec_input.hpp"
+#include "fuzzuf/mutator/mutator.hpp"
+#include "fuzzuf/optimizer/optimizer.hpp"
+#include "fuzzuf/utils/hex_dump.hpp"
+
+// Mutator needs "Tag" which represents what algorithm is going to use Mutator.
+// We just prepare a temporary Tag.
+struct TestTag {};
+
+// This class just returns a constant that is passed during construction.
+// Instances of this class is used as mutop_optimizer in Havoc
+// to test the probability distribution of selecting mutation operators
+class ConstantMutopSelector : public fuzzuf::optimizer::Optimizer<u32> {
+ public:
+  ConstantMutopSelector(u32 ret) : ret(ret) {}
+  u32 CalcValue() override { return ret; }
+
+ private:
+  u32 ret;
+};
+
+// Check if Mutator::Havoc crashes or causes any access violations.
+// At the same time, this test makes sure that all the switch cases
+// beyond mutator::NUM_CASE are implemented without omissions in Havoc.
+BOOST_AUTO_TEST_CASE(MutatorMoreHavoc) {
+  // We prepare (AFLPLUSPLUS_NUM_CASE - mutator::NUM_CASE) number of
+  // distributions. The i-th distribution always returns i. That is, chances of
+  // the integer i being returned are 100%. Using these distributions, we can
+  // check if each switch case is really implemented, and doesn't crash.
+
+  // The seed can be anything, but it should be long to some extent
+  // and all its bytes should be different.
+  std::vector<u8> seed(100);
+  std::iota(seed.begin(), seed.end(), 1);
+
+  // Also, extras and a_extras can be anything, but they should have at least
+  // one element.
+  using fuzzuf::algorithm::afl::dictionary::AFLDictData;
+  std::vector<AFLDictData> extras(1, AFLDictData({100, 101, 102, 103}));
+  std::vector<AFLDictData> a_extras(1, AFLDictData({'H', 'e', 'l', 'l', 'o'}));
+
+  fuzzuf::exec_input::ExecInputSet
+      input_set;  // to create OnMemoryInputSet, we need the set(factory)
+
+  std::cout
+      << "Going to check mutations provided by AFLplusplus custom cases..."
+      << std::endl;
+  namespace pph = fuzzuf::algorithm::aflplusplus::havoc;
+  for (u32 i = pph::AFLPLUSPLUS_ADDBYTE; i < pph::AFLPLUSPLUS_NUM_CASE; i++) {
+    std::cout << "check the " << i << "-th mutation." << std::endl;
+
+    // Create an instance of Mutator.
+    auto input = input_set.CreateOnMemory(&seed[0], seed.size());
+    auto mutator = fuzzuf::mutator::Mutator<TestTag>(*input);
+
+    // Create the i-th distribution.
+    auto case_dist = ConstantMutopSelector(i);
+
+    mutator.Havoc(1024, extras, a_extras, case_dist,
+                  pph::AFLplusplusCustomCases);
+
+    // Make sure that Havoc actually modified the input.
+    std::vector<u8> modified_seed(mutator.GetBuf(),
+                                  mutator.GetBuf() + mutator.GetLen());
+    BOOST_CHECK(seed != modified_seed);
+  }
+
+  // Make sure that Havoc passes through the default case
+  // when a distribution return an integer other than 0, 1, ..., NUM_CASE-1
+  auto input = input_set.CreateOnMemory(&seed[0], seed.size());
+  auto mutator = fuzzuf::mutator::Mutator<TestTag>(*input);
+
+  // Create a distribution that always returns NUM_CASE.
+  auto case_dist = ConstantMutopSelector(pph::AFLPLUSPLUS_NUM_CASE);
+
+  bool passed_custom_cases = false;
+  auto custom_cases = [&passed_custom_cases](u32 r, u8*, u32,
+                                             const std::vector<AFLDictData>&,
+                                             const std::vector<AFLDictData>&) {
+    // AFLplusplus's mutations always fall into custom cases.
+    // If r >= AFLPLUSPLUS_NUM_CASE, then it will jump to the default case as
+    // expected.
+    if (r >= pph::AFLPLUSPLUS_NUM_CASE) passed_custom_cases = true;
+  };
+  mutator.Havoc(1, extras, a_extras, case_dist, custom_cases);
+
+  BOOST_CHECK(passed_custom_cases);
+
+  // Because custom_cases does nothing this time, the input cannot be modified.
+  std::vector<u8> modified_seed(mutator.GetBuf(),
+                                mutator.GetBuf() + mutator.GetLen());
+  BOOST_CHECK(seed == modified_seed);
+}


### PR DESCRIPTION
<!-- Set a title that summarizes the PR changes. -->

## Type of PR
<!-- This project uses issue-driven development, so please take the appropriate action for each PR type. -->

- [x] Changes related to the roadmap (e.g., TODO.md) (type: A) -> Create an issue corresponding to the PR in advance, and refer to this PR in the issue.
- Changes that are not related to the roadmap
    - [ ] Change with multiple possible solutions to the issue (type: B-1) -> Create an issue corresponding to the PR in advance and refer to this PR in the issue.
    - [ ] Change with a single solution (type: B-2) -> There is no need to create an issue corresponding to the PR in advance. Please discuss it in this PR.

## Related Issue
<!-- If this PR is a PR type A/B-1, please provide a link to the corresponding issue. -->
<!-- If this PR is a PR type B-1, please write "N/A" -->

## Importance of PR
<!-- Please describe the importance of the PR in terms of the following aspects. -->

- Importance of the issue
    - [x] Large (based on several days to weeks of discussion and verification, e.g., this issue is a blocking issue for other issues on the roadmap, etc.)
    - [ ] Medium (based on a few hours to a day of discussion and verification, e.g., this issue is a blocking issue for another minor issue)
    - [ ] Small (apparent changes such as build error)
- Complexity of the solution (code, tests, etc.)
    - [x] Large (requires several days to several weeks of review)
    - [ ] Medium (requires several hours to a day of review)
    - [ ] Small (trivial changes, such as build error)

## PR Overview
<!-- Please provide a summary of this PR. -->
<!-- If this PR is a PR type A/B-1, this PR will be considered as an item in the checklist for the related issue. Please provide a link to the issue comment that contains the checklist. -->
<!-- If this PR is a PR type B-2, unnecessary to reference the issue. Please provide a summary. -->
This PR introduces AFLplusplus into a collection of fuzzers. There are mainly four features/improvements made compared to the original AFL in terms of fuzzer-side (i.e. not a compiler-side, modifying clang or LLVM)

### AFLFast3 (improvements in seed weight computation and power scheduling)
Originally provided as a patch to improve scheduling (a way to compute seed's score) for AFLplusplus/AFLplusplus by Marcel Boehme (an author of AFLFast) in AFLplusplus/AFLplusplus@e87eca7f (later improved by AFLplusplus developers). 

Moreover, the patch changes `n_fuzz` from u32 in `struct queue_entry` (which is equivalent to `Testcase` in fuzzuf) to an array of u32 in `struct afl_state` (equivalent to `AFLState` in fuzzuf), and `queue_entry` now holds `n_fuzz_entry`, which is an index number for that array.  
This is to resolve the performance bottleneck where AFL++ tried to match checksum in a while-loop naively. 

As a side-note, it seemed the original AFLplusplus's code may perform div by zero in LIN or QUAD scheduling, so fuzzuf is aware of that. 

### more_havoc (better havoc)

They also added several new mutations to havoc with their probability to be chosen. It is unclear what that probability is based on. 

The first change occurred in AFLplusplus/AFLplusplus@70bf4b4a as `havoc2` (a name of the merged branch)  to change the uniform probability of mutations to make them have their own values. 

Nextly, new mutations came in at AFLplusplus/AFLplusplus@b8e61da8 as `more_havoc`. This PR reflects those probabilities with Walker's alias distribution.

### alias scheduling

Although the original AFL selects its seeds sequentially, it was pointed out that choosing them randomly produces a better fuzzing result. 

Therefore, AFL++ adopted a random seed selection with Walker's alias method at AFLplusplus/AFLplusplus@6a397d61. At this point, weights (values) used to create the alias table are based on the conventional `calculate_score()` function. 

Thereafter, a patch by Marcel Boehme (AFLplusplus/AFLplusplus@06ec5ab3) changed AFL++ to use the new `compute_weight` function to create it. The purpose of this patch was:
> This commit extends the weight-based sampling by assigning weights based on how often the seed's path is exercised, the number of branches it covers, and the time it takes to execute.

### xxHash
Already merged in #85 

### Disable deterministic mutations by default

Deterministic mutations are disabled by default in fuzzuf's AFLplusplus as the original does. Users can still enable them with `-D [--det]` flag. 

### Schedules are selectable in CLI

Users can specify a power schedule to use with `-p [--schedule]` flag (defaults to FAST scheduling as the original does).

### Other potential improvements may be ported
There were several other fuzzer-side improvements, for example, xoshiro256 or RomuDuoJr (better PRNGs compared to Glibc `random`). However, introducing this PRNG requires changing the prototype of `UR()` function to pass `AFLState` and that seemed too much. Therefore, this PR does not include such changes. 

## Concerns (Optional)
<!-- If you have any concerns, please describe them clearly by filling in the relevant checklist items below. If there is anything else you would like to share with the reviewer, please include it. -->

- [ ] Performance
- [x] Source Code Quality

To complete the implementation of `more_havoc`, `ChooseBlockLen` function has been copied from `mutator.hpp` since using one at the original location requires a change in function prototypes a lot. Still looking for a better way to solve this.

---

> The PR author should fill in the following checklist when submitting this PR.

#### Optional Entries
- [ ] If this PR is a PR type A/B-1, there is a cross-link between this PR and the related issue.

#### Mandatory Entries
- [x] The PR title is a summary of the changes.
- [x] Completed each required field of the PR.

---
> The PR author should fill out the following checklist in the comments to confirm that this PR is ready to be merged

- [ ] CI is green or confirmed test run results.
- [ ] All change suggestions from reviewers have been resolved (fixed or foregone).

---
> The maintainer of this repository will set up a reviewer for each PR.
> PR reviewers should review this PR in terms of the checklist below before moving on to a detailed code review. Please comment on their initial response by filling in the checklist below.

#### Optional Entries
- [ ] The reviewer assigned more reviewers if needed.
- [ ] The reviewer noted that it is necessary to break out some of the changes in this PR into other PRs if needed.
- [ ] The reviewer noted that the initial response is insufficient if needed.

#### Mandatory Entries
- [ ] The title of this PR summarizes the changes made by this PR properly.
- [ ] The target branch of this PR is as intended.
- [ ] The reviewer understands the issues in this PR.
- [ ] The reviewer plans to review with an appropriate workload based on the importance of this PR.

---
> When the PR reviewer concludes that this PR is ready to be merged, please fill in the checklist below by posting it in the comment. If there is more than one reviewer, please do this on your own.

#### Optional Entries
- [ ] The reviewer noted that if you believe that new tests are needed to evaluate this PR, they have been noted.
- [ ] If minor refactorings are not mentioned in the PR, I understand the intent.
- [ ] If this PR is a PR type A/B-1, we have agreed on this PR's design, direction, and granularity in the related issue.

#### Mandatory Entries
- [ ] The reviewer understands how this PR addresses the issue and the specific changes.
- [ ] This PR uses the best possible issue resolution that the reviewer can think of.
- [ ] This PR is ready to be merged.
