### PR TITLE
Fix the issue of AFL++ halting by producing NaN in calculating weights of seeds

### DIFF
--- a/include/fuzzuf/algorithms/aflplusplus/aflplusplus_util.hpp
+++ b/include/fuzzuf/algorithms/aflplusplus/aflplusplus_util.hpp
@@ -50,8 +50,8 @@ double ComputeWeight(const State &state,
   }
 
   weight *= ((avg_exec_us + epsilon) / (testcase.exec_us + epsilon));
-  weight *= (std::log(testcase.bitmap_size + 1) / avg_bitmap_size);
-  weight *= (1 + ((testcase.tc_ref + epsilon) / (avg_top_size + epsilon)));
+  weight *= (std::log(testcase.bitmap_size + 1) / (avg_bitmap_size + epsilon));
+  weight *= (1 + (testcase.tc_ref / (avg_top_size + epsilon)));
   if (unlikely(testcase.favored)) {
     weight *= 5;
   }


### PR DESCRIPTION
<!-- Set a title that summarizes the PR changes. -->

## Type of PR
<!-- This project uses issue-driven development, so please take the appropriate action for each PR type. -->

- [ ] Changes related to the roadmap (e.g., TODO.md) (type: A) -> Create an issue corresponding to the PR in advance, and refer to this PR in the issue.
- Changes that are not related to the roadmap
    - [ ] Change with multiple possible solutions to the issue (type: B-1) -> Create an issue corresponding to the PR in advance and refer to this PR in the issue.
    - [x] Change with a single solution (type: B-2) -> There is no need to create an issue corresponding to the PR in advance. Please discuss it in this PR.

## Related Issue
<!-- If this PR is a PR type A/B-1, please provide a link to the corresponding issue. -->
<!-- If this PR is a PR type B-1, please write "N/A" -->

## Importance of PR
<!-- Please describe the importance of the PR in terms of the following aspects. -->

- Importance of the issue
    - [ ] Large (based on several days to weeks of discussion and verification, e.g., this issue is a blocking issue for other issues on the roadmap, etc.)
    - [x] Medium (based on a few hours to a day of discussion and verification, e.g., this issue is a blocking issue for another minor issue)
    - [ ] Small (apparent changes such as build error)
- Complexity of the solution (code, tests, etc.)
    - [ ] Large (requires several days to several weeks of review)
    - [ ] Medium (requires several hours to a day of review)
    - [x] Small (trivial changes, such as build error)

## PR Overview
<!-- Please provide a summary of this PR. -->
<!-- If this PR is a PR type A/B-1, this PR will be considered as an item in the checklist for the related issue. Please provide a link to the issue comment that contains the checklist. -->
<!-- If this PR is a PR type B-2, unnecessary to reference the issue. Please provide a summary. -->

As the title suggests, currently fuzzuf's AFL++ has a bug that makes fuzzer instances randomly halt after some time:
```bash
fuzzuf-aflpp-second-bench$ tail -n 2 oss-xpdf/9/dump/afl.log 
[*] Fuzzing test case #3238 (5229 total, 26 uniq crashes found)...
[!] Weight must not be negative or NaN
```

According to the above stdout log, the instance halted because of the uncaught exception thrown here: 
https://github.com/fuzzuf/fuzzuf/blob/10ef1cb28260bde740edcd2590b0147fb5e2fe67/include/fuzzuf/utils/random.hpp#L126

Since `WalkerDiscreteDistribution` is used only in selecting a seed to be mutated in AFL++, the root cause was found quickly:
https://github.com/fuzzuf/fuzzuf/blob/10ef1cb28260bde740edcd2590b0147fb5e2fe67/include/fuzzuf/algorithms/aflplusplus/aflplusplus_util.hpp#L48-L50

These multiplying terms all can result in NaN in some rare cases. Especially, `bitmap_size` can be easily 0 while this is not the case in the original AFL++ because it writes 1 to `bitmap[0]` anyways first.
Also, it is very notable that I observed the case where `testcase.exec_us` is 0. 
So just in case, the other two terms than `bitmap_size` should be also fixed.

I confirmed that fuzzer instances never halted during 24 hours by introducing this PR and running the same evaluation as https://github.com/fuzzuf/fuzzuf/issues/94:

![Screenshot from 2023-03-30 19-07-20](https://user-images.githubusercontent.com/1556747/228803989-d58394a2-b742-404d-bf10-9d08ceec01e3.png)
The pink curves are taken before the patch and the green ones after. As you can see, before introducing the PR, the curves are cut in the middle in 3 programs, which means fuzzer instances halted during the evaluation.

## Concerns (Optional)
<!-- If you have any concerns, please describe them clearly by filling in the relevant checklist items below. If there is anything else you would like to share with the reviewer, please include it. -->

- [ ] Performance
- [ ] Source Code Quality

---

> The PR author should fill in the following checklist when submitting this PR.

#### Optional Entries
- [ ] If this PR is a PR type A/B-1, there is a cross-link between this PR and the related issue.
t
#### Mandatory Entries
- [x] The PR title is a summary of the changes.
- [x] Completed each required field of the PR.

---
> The PR author should fill out the following checklist in the comments to confirm that this PR is ready to be merged

- [ ] CI is green or confirmed test run results.
- [ ] All change suggestions from reviewers have been resolved (fixed or foregone).

---
> The maintainer of this repository will set up a reviewer for each PR.
> PR reviewers should review this PR in terms of the checklist below before moving on to a detailed code review. Please comment on their initial response by filling in the checklist below.

#### Optional Entries
- [ ] The reviewer assigned more reviewers if needed.
- [ ] The reviewer noted that it is necessary to break out some of the changes in this PR into other PRs if needed.
- [ ] The reviewer noted that the initial response is insufficient if needed.

#### Mandatory Entries
- [ ] The title of this PR summarizes the changes made by this PR properly.
- [ ] The target branch of this PR is as intended.
- [ ] The reviewer understands the issues in this PR.
- [ ] The reviewer plans to review with an appropriate workload based on the importance of this PR.

---
> When the PR reviewer concludes that this PR is ready to be merged, please fill in the checklist below by posting it in the comment. If there is more than one reviewer, please do this on your own.

#### Optional Entries
- [ ] The reviewer noted that if you believe that new tests are needed to evaluate this PR, they have been noted.
- [ ] If minor refactorings are not mentioned in the PR, I understand the intent.
- [ ] If this PR is a PR type A/B-1, we have agreed on this PR's design, direction, and granularity in the related issue.

#### Mandatory Entries
- [ ] The reviewer understands how this PR addresses the issue and the specific changes.
- [ ] This PR uses the best possible issue resolution that the reviewer can think of.
- [ ] This PR is ready to be merged.
