### PR TITLE
Fix batch sizes returned by SloptOptimizer

### DIFF
--- a/include/fuzzuf/algorithms/aflplusplus/aflplusplus_option.hpp
+++ b/include/fuzzuf/algorithms/aflplusplus/aflplusplus_option.hpp
@@ -18,6 +18,7 @@
 #ifndef FUZZUF_INCLUDE_ALGORITHM_AFLPLUSPLUS_AFLPLUSPLUS_OPTION_HPP
 #define FUZZUF_INCLUDE_ALGORITHM_AFLPLUSPLUS_AFLPLUSPLUS_OPTION_HPP
 
+#include "fuzzuf/algorithms/afl/afl_option.hpp"
 #include "fuzzuf/algorithms/aflfast/aflfast_option.hpp"
 
 namespace fuzzuf::algorithm::aflplusplus::option {
@@ -30,4 +31,14 @@ constexpr u32 GetNFuzzSize(void) {
 }
 
 }  // namespace fuzzuf::algorithm::aflplusplus::option
+
+namespace fuzzuf::algorithm::afl::option {
+
+template <>
+constexpr u32 GetHavocStackPow2<aflplusplus::option::AFLplusplusTag>(void) {
+  return 6;
+}
+
+}  // namespace fuzzuf::algorithm::afl::option
+
 #endif

--- a/include/fuzzuf/algorithms/rezzuf/rezzuf_option.hpp
+++ b/include/fuzzuf/algorithms/rezzuf/rezzuf_option.hpp
@@ -19,10 +19,21 @@
 #ifndef FUZZUF_INCLUDE_ALGORITHM_REZZUF_REZZUF_OPTION_HPP
 #define FUZZUF_INCLUDE_ALGORITHM_REZZUF_REZZUF_OPTION_HPP
 
+#include "fuzzuf/algorithms/afl/afl_option.hpp"
+
 namespace fuzzuf::algorithm::rezzuf::option {
 
 struct RezzufTag {};
 
 }  // namespace fuzzuf::algorithm::rezzuf::option
+
+namespace fuzzuf::algorithm::afl::option {
+
+template <>
+constexpr u32 GetHavocStackPow2<rezzuf::option::RezzufTag>(void) {
+  return 6;
+}
+
+}  // namespace fuzzuf::algorithm::afl::option
 
 #endif

--- a/include/fuzzuf/cli/fuzzer/aflplusplus/build_aflplusplus_fuzzer_from_args.hpp
+++ b/include/fuzzuf/cli/fuzzer/aflplusplus/build_aflplusplus_fuzzer_from_args.hpp
@@ -206,8 +206,7 @@ std::unique_ptr<TFuzzer> BuildAFLplusplusFuzzerFromArgs(
           GetExecTimeout<AFLplusplusTag>()),
       mem_limit, aflplusplus_options.forksrv,
       /* dumb_mode */ false,  // FIXME: add dumb_mode
-      global_options.cpuid_to_bind, schedule,
-      aflplusplus_options.schedule);
+      global_options.cpuid_to_bind, schedule, aflplusplus_options.schedule);
 
   // NativeLinuxExecutor needs the directory specified by "out_dir" to be
   // already set up so we need to create the directory first, and then
@@ -283,7 +282,7 @@ std::unique_ptr<TFuzzer> BuildAFLplusplusFuzzerFromArgs(
 
     havoc_optimizer.reset(new optimizer::slopt::SloptOptimizer(
         AFLPLUSPLUS_NUM_CASE, GetMaxFile<AFLplusplusTag>(),
-        GetHavocStackPow2<AFLplusplusTag>()));
+        GetHavocStackPow2<AFLplusplusTag>() + 1));
   } else {
     std::unique_ptr<optimizer::Optimizer<u32>> mutop_optimizer(
         new algorithm::aflplusplus::havoc::AFLplusplusHavocCaseDistrib());

--- a/include/fuzzuf/cli/fuzzer/aflplusplus/build_aflplusplus_fuzzer_from_args.hpp
+++ b/include/fuzzuf/cli/fuzzer/aflplusplus/build_aflplusplus_fuzzer_from_args.hpp
@@ -282,7 +282,7 @@ std::unique_ptr<TFuzzer> BuildAFLplusplusFuzzerFromArgs(
 
     havoc_optimizer.reset(new optimizer::slopt::SloptOptimizer(
         AFLPLUSPLUS_NUM_CASE, GetMaxFile<AFLplusplusTag>(),
-        GetHavocStackPow2<AFLplusplusTag>() + 1));
+        GetHavocStackPow2<AFLplusplusTag>()));
   } else {
     std::unique_ptr<optimizer::Optimizer<u32>> mutop_optimizer(
         new algorithm::aflplusplus::havoc::AFLplusplusHavocCaseDistrib());

--- a/include/fuzzuf/cli/fuzzer/rezzuf/build_rezzuf_fuzzer_from_args.hpp
+++ b/include/fuzzuf/cli/fuzzer/rezzuf/build_rezzuf_fuzzer_from_args.hpp
@@ -263,7 +263,7 @@ std::unique_ptr<TFuzzer> BuildRezzufFuzzerFromArgs(
   std::unique_ptr<optimizer::HavocOptimizer> havoc_optimizer(
       new optimizer::slopt::SloptOptimizer(AFLPLUSPLUS_NUM_CASE,
                                            GetMaxFile<RezzufTag>(),
-                                           GetHavocStackPow2<RezzufTag>()));
+                                           GetHavocStackPow2<RezzufTag>() + 1));
 
   // Create RezzufState
   using fuzzuf::algorithm::rezzuf::RezzufState;

--- a/include/fuzzuf/cli/fuzzer/rezzuf/build_rezzuf_fuzzer_from_args.hpp
+++ b/include/fuzzuf/cli/fuzzer/rezzuf/build_rezzuf_fuzzer_from_args.hpp
@@ -263,7 +263,7 @@ std::unique_ptr<TFuzzer> BuildRezzufFuzzerFromArgs(
   std::unique_ptr<optimizer::HavocOptimizer> havoc_optimizer(
       new optimizer::slopt::SloptOptimizer(AFLPLUSPLUS_NUM_CASE,
                                            GetMaxFile<RezzufTag>(),
-                                           GetHavocStackPow2<RezzufTag>() + 1));
+                                           GetHavocStackPow2<RezzufTag>()));
 
   // Create RezzufState
   using fuzzuf::algorithm::rezzuf::RezzufState;

--- a/optimizer/slopt/slopt_optimizer.cpp
+++ b/optimizer/slopt/slopt_optimizer.cpp
@@ -59,7 +59,7 @@ u32 SloptOptimizer::CalcBatchSize() {
   prev_pulled_batch =
       bat_bandits[prev_bucket_idx][prev_pulled_mutop].PullArm({});
 
-  return prev_pulled_batch;
+  return 1u << prev_pulled_batch;
 }
 
 u32 SloptOptimizer::CalcMutop([[maybe_unused]] u32 batch_idx) {


### PR DESCRIPTION
<!-- Set a title that summarizes the PR changes. -->

## Type of PR
<!-- This project uses issue-driven development, so please take the appropriate action for each PR type. -->

- [ ] Changes related to the roadmap (e.g., TODO.md) (type: A) -> Create an issue corresponding to the PR in advance, and refer to this PR in the issue.
- Changes that are not related to the roadmap
    - [ ] Change with multiple possible solutions to the issue (type: B-1) -> Create an issue corresponding to the PR in advance and refer to this PR in the issue.
    - [x] Change with a single solution (type: B-2) -> There is no need to create an issue corresponding to the PR in advance. Please discuss it in this PR.

## Related Issue
<!-- If this PR is a PR type A/B-1, please provide a link to the corresponding issue. -->
<!-- If this PR is a PR type B-1, please write "N/A" -->

## Importance of PR
<!-- Please describe the importance of the PR in terms of the following aspects. -->

- Importance of the issue
    - [ ] Large (based on several days to weeks of discussion and verification, e.g., this issue is a blocking issue for other issues on the roadmap, etc.)
    - [x] Medium (based on a few hours to a day of discussion and verification, e.g., this issue is a blocking issue for another minor issue)
    - [ ] Small (apparent changes such as build error)
- Complexity of the solution (code, tests, etc.)
    - [ ] Large (requires several days to several weeks of review)
    - [ ] Medium (requires several hours to a day of review)
    - [x] Small (trivial changes, such as build error)

## PR Overview
<!-- Please provide a summary of this PR. -->
<!-- If this PR is a PR type A/B-1, this PR will be considered as an item in the checklist for the related issue. Please provide a link to the issue comment that contains the checklist. -->
<!-- If this PR is a PR type B-2, unnecessary to reference the issue. Please provide a summary. -->

I found the following two issues related to each other and this PR fixes them:
  - The configurable value `afl::option::GetHavocStackPow2` (defined in https://github.com/fuzzuf/fuzzuf/blob/dfd3a9ea2afd138fdc3d08c997c9092a18120926/include/fuzzuf/algorithms/afl/afl_option.hpp#L164-L167 . originally defined in AFL; https://github.com/google/AFL/blob/82b5e359463238d790cadbe2dd494d6a4928bff3/config.h#L112) actually should be set differently in AFL++ (it's 4 at the beginning; https://github.com/AFLplusplus/AFLplusplus/blob/0c0a6c3bfabf0facaed33fae1aa5ad54a6a11b32/include/config.h#L197 . Finally, it becomes 6; https://github.com/AFLplusplus/AFLplusplus/blob/0c0a6c3bfabf0facaed33fae1aa5ad54a6a11b32/src/afl-fuzz.c#L2462-L2470).
  - SloptOptimizer returns wrong batch sizes due to a missing left-shift operation (compare the followings: https://github.com/RICSecLab/SLOPTAFLpp/blob/bcedc0492f52cb0dc0f86922131cf195550f1a8d/src/afl-fuzz-one.c#L3018 , https://github.com/fuzzuf/fuzzuf/blob/dfd3a9ea2afd138fdc3d08c997c9092a18120926/optimizer/slopt/slopt_optimizer.cpp#L62).

Note that, while AFL++ uses 2(=2^1), 4(=2^2), ..., 64(=2^6) as batch sizes, SLOPT-AFL++ uses 1(=2^0), ..., 64 (See https://github.com/RICSecLab/SLOPTAFLpp/blob/bcedc0492f52cb0dc0f86922131cf195550f1a8d/include/afl-fuzz.h#L647 ; https://github.com/RICSecLab/SLOPTAFLpp/blob/bcedc0492f52cb0dc0f86922131cf195550f1a8d/src/afl-fuzz-state.c#L177).
Therefore,  the correct number of bandit arms is `GetHavocStackPow2<AFLplusplusTag>() + 1` (=6+1) as fixed in this PR.


## Concerns (Optional)
<!-- If you have any concerns, please describe them clearly by filling in the relevant checklist items below. If there is anything else you would like to share with the reviewer, please include it. -->

- [ ] Performance
- [ ] Source Code Quality

---

> The PR author should fill in the following checklist when submitting this PR.

#### Optional Entries
- [ ] If this PR is a PR type A/B-1, there is a cross-link between this PR and the related issue.

#### Mandatory Entries
- [x] The PR title is a summary of the changes.
- [x] Completed each required field of the PR.

---
> The PR author should fill out the following checklist in the comments to confirm that this PR is ready to be merged

- [ ] CI is green or confirmed test run results.
- [ ] All change suggestions from reviewers have been resolved (fixed or foregone).

---
> The maintainer of this repository will set up a reviewer for each PR.
> PR reviewers should review this PR in terms of the checklist below before moving on to a detailed code review. Please comment on their initial response by filling in the checklist below.

#### Optional Entries
- [ ] The reviewer assigned more reviewers if needed.
- [ ] The reviewer noted that it is necessary to break out some of the changes in this PR into other PRs if needed.
- [ ] The reviewer noted that the initial response is insufficient if needed.

#### Mandatory Entries
- [ ] The title of this PR summarizes the changes made by this PR properly.
- [ ] The target branch of this PR is as intended.
- [x] The reviewer understands the issues in this PR.
- [x] The reviewer plans to review with an appropriate workload based on the importance of this PR.

---
> When the PR reviewer concludes that this PR is ready to be merged, please fill in the checklist below by posting it in the comment. If there is more than one reviewer, please do this on your own.

#### Optional Entries
- [ ] The reviewer noted that if you believe that new tests are needed to evaluate this PR, they have been noted.
- [ ] If minor refactorings are not mentioned in the PR, I understand the intent.
- [ ] If this PR is a PR type A/B-1, we have agreed on this PR's design, direction, and granularity in the related issue.

#### Mandatory Entries
- [x] The reviewer understands how this PR addresses the issue and the specific changes.
- [x] This PR uses the best possible issue resolution that the reviewer can think of.
- [x] This PR is ready to be merged.
