### PR TITLE
fix cmake not to treat a list as multiple arguments

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -466,7 +466,7 @@ link_directories(
 )
 
 add_subdirectory(algorithms)
-algorithm_enabled( python_wrapper_enabled ${ALGORITHMS} "python" )
+algorithm_enabled( python_wrapper_enabled "${ALGORITHMS}" "python" )
 if( python_wrapper_enabled )
   add_subdirectory(python)
 endif()

--- a/python/python_hierarflow_routines.cpp
+++ b/python/python_hierarflow_routines.cpp
@@ -130,7 +130,7 @@ utils::NullableRef<hierarflow::HierarFlowCallee<void(u32)>> PyHavoc::operator()(
 
   using algorithm::afl::dictionary::AFLDictData;
 
-  ConstantBatchHavocOptimizer havoc_optimizer(1 << stacking, mutop_optimizer);
+  optimizer::ConstantBatchHavocOptimizer havoc_optimizer(1 << stacking, mutop_optimizer);
   mutator.Havoc({}, {}, havoc_optimizer,
                 [](u32, u8*&, u32&, const std::vector<AFLDictData>&,
                    const std::vector<AFLDictData>&) {});

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -10,7 +10,7 @@ subdirs(
   util
   put
 )
-algorithm_enabled( python_wrapper_enabled ${ALGORITHMS} "python" )
+algorithm_enabled( python_wrapper_enabled "${ALGORITHMS}" "python" )
 if( python_wrapper_enabled )
 subdirs(
   fuzzer
@@ -19,7 +19,7 @@ subdirs(
   python
 )
 endif()
-afl_common_is_required( enable_afl_common ${ALGORITHMS} )
+afl_common_is_required( enable_afl_common "${ALGORITHMS}" )
 if( enable_afl_common )
 subdirs(
   mutator

--- a/tools/dict2mp/CMakeLists.txt
+++ b/tools/dict2mp/CMakeLists.txt
@@ -1,4 +1,4 @@
-algorithm_enabled(ENABLE_LIBFUZZER ${ALGORITHMS} libfuzzer)
+algorithm_enabled(ENABLE_LIBFUZZER "${ALGORITHMS}" libfuzzer)
 if( ENABLE_LIBFUZZER )
 add_executable( dict2mp dict2mp.cpp )
 target_link_libraries(

--- a/tools/nautilus/CMakeLists.txt
+++ b/tools/nautilus/CMakeLists.txt
@@ -1,4 +1,4 @@
-algorithm_enabled(ENABLE_NAUTILUS ${ALGORITHMS} nautilus)
+algorithm_enabled(ENABLE_NAUTILUS "${ALGORITHMS}" nautilus)
 if( ENABLE_NAUTILUS )
 add_executable( generator generator.cpp )
 target_link_libraries(


### PR DESCRIPTION
<!-- Set a title that summarizes the PR changes. -->

## Type of PR
<!-- This project uses issue-driven development, so please take the appropriate action for each PR type. -->

- [ ] Changes related to the roadmap (e.g., TODO.md) (type: A) -> Create an issue corresponding to the PR in advance, and refer to this PR in the issue.
- Changes that are not related to the roadmap
    - [ ] Change with multiple possible solutions to the issue (type: B-1) -> Create an issue corresponding to the PR in advance and refer to this PR in the issue.
    - [x] Change with a single solution (type: B-2) -> There is no need to create an issue corresponding to the PR in advance. Please discuss it in this PR.

## Related Issue
<!-- If this PR is a PR type A/B-1, please provide a link to the corresponding issue. -->
<!-- If this PR is a PR type B-1, please write "N/A" -->

## Importance of PR
<!-- Please describe the importance of the PR in terms of the following aspects. -->

- Importance of the issue
    - [ ] Large (based on several days to weeks of discussion and verification, e.g., this issue is a blocking issue for other issues on the roadmap, etc.)
    - [ ] Medium (based on a few hours to a day of discussion and verification, e.g., this issue is a blocking issue for another minor issue)
    - [x] Small (apparent changes such as build error)
- Complexity of the solution (code, tests, etc.)
    - [ ] Large (requires several days to several weeks of review)
    - [ ] Medium (requires several hours to a day of review)
    - [x] Small (trivial changes, such as build error)

## PR Overview
<!-- Please provide a summary of this PR. -->
<!-- If this PR is a PR type A/B-1, this PR will be considered as an item in the checklist for the related issue. Please provide a link to the issue comment that contains the checklist. -->
<!-- If this PR is a PR type B-2, unnecessary to reference the issue. Please provide a summary. -->

In CMake scripts, if we pass a list (say, `SOME_LIST`) to a function without double quotes (`func(${SOME_LIST})`, not `func("${SOME_LIST}")`), CMake expands the list as multiple arguments, just like Python's `*list` .
In our build script, this made the `python/` subdirectory unintentionally always disabled.

This PR fixes this issue.

## Concerns (Optional)
<!-- If you have any concerns, please describe them clearly by filling in the relevant checklist items below. If there is anything else you would like to share with the reviewer, please include it. -->

- [ ] Performance
- [ ] Source Code Quality

---

> The PR author should fill in the following checklist when submitting this PR.

#### Optional Entries
- [ ] If this PR is a PR type A/B-1, there is a cross-link between this PR and the related issue.

#### Mandatory Entries
- [x] The PR title is a summary of the changes.
- [x] Completed each required field of the PR.

---
> The PR author should fill out the following checklist in the comments to confirm that this PR is ready to be merged

- [ ] CI is green or confirmed test run results.
- [ ] All change suggestions from reviewers have been resolved (fixed or foregone).

---
> The maintainer of this repository will set up a reviewer for each PR.
> PR reviewers should review this PR in terms of the checklist below before moving on to a detailed code review. Please comment on their initial response by filling in the checklist below.

#### Optional Entries
- [ ] The reviewer assigned more reviewers if needed.
- [ ] The reviewer noted that it is necessary to break out some of the changes in this PR into other PRs if needed.
- [ ] The reviewer noted that the initial response is insufficient if needed.

#### Mandatory Entries
- [ ] The title of this PR summarizes the changes made by this PR properly.
- [ ] The target branch of this PR is as intended.
- [ ] The reviewer understands the issues in this PR.
- [ ] The reviewer plans to review with an appropriate workload based on the importance of this PR.

---
> When the PR reviewer concludes that this PR is ready to be merged, please fill in the checklist below by posting it in the comment. If there is more than one reviewer, please do this on your own.

#### Optional Entries
- [ ] The reviewer noted that if you believe that new tests are needed to evaluate this PR, they have been noted.
- [ ] If minor refactorings are not mentioned in the PR, I understand the intent.
- [ ] If this PR is a PR type A/B-1, we have agreed on this PR's design, direction, and granularity in the related issue.

#### Mandatory Entries
- [ ] The reviewer understands how this PR addresses the issue and the specific changes.
- [ ] This PR uses the best possible issue resolution that the reviewer can think of.
- [ ] This PR is ready to be merged.
