### PR TITLE
Make `GetHavocStackPow2<Tag>` correctly used in AFLHavocOptimizer

### DIFF
--- a/algorithms/afl_common/afl_havoc_optimizer.cpp
+++ b/algorithms/afl_common/afl_havoc_optimizer.cpp
@@ -26,9 +26,9 @@
 namespace fuzzuf::algorithm::afl {
 
 AFLHavocOptimizer::AFLHavocOptimizer(
-    std::shared_ptr<optimizer::Optimizer<u32>> _mutop_optimizer, int _havoc_stack_pow)
-    : mutop_optimizer(_mutop_optimizer),
-      havoc_stack_pow(_havoc_stack_pow) {}
+    std::shared_ptr<optimizer::Optimizer<u32>> _mutop_optimizer,
+    int _havoc_stack_pow)
+    : mutop_optimizer(_mutop_optimizer), havoc_stack_pow(_havoc_stack_pow) {}
 
 AFLHavocOptimizer::~AFLHavocOptimizer() {}
 

--- a/algorithms/afl_common/afl_havoc_optimizer.cpp
+++ b/algorithms/afl_common/afl_havoc_optimizer.cpp
@@ -26,8 +26,9 @@
 namespace fuzzuf::algorithm::afl {
 
 AFLHavocOptimizer::AFLHavocOptimizer(
-    std::shared_ptr<optimizer::Optimizer<u32>> _mutop_optimizer)
-    : mutop_optimizer(_mutop_optimizer) {}
+    std::shared_ptr<optimizer::Optimizer<u32>> _mutop_optimizer, int _havoc_stack_pow)
+    : mutop_optimizer(_mutop_optimizer),
+      havoc_stack_pow(_havoc_stack_pow) {}
 
 AFLHavocOptimizer::~AFLHavocOptimizer() {}
 
@@ -38,7 +39,7 @@ u32 AFLHavocOptimizer::CalcMutop([[maybe_unused]] u32 batch_idx) {
 u32 AFLHavocOptimizer::CalcBatchSize() {
   // FIXME: UR should be replaced with a new random number generator when it's
   // ready
-  return 1 << (1 + util::UR(option::GetHavocStackPow2<option::AFLTag>(), -1));
+  return 1 << (1 + util::UR(havoc_stack_pow, -1));
 }
 
 void AFLHavocOptimizer::UpdateInternalState() {}

--- a/include/fuzzuf/algorithms/afl/afl_havoc_optimizer.hpp
+++ b/include/fuzzuf/algorithms/afl/afl_havoc_optimizer.hpp
@@ -29,7 +29,8 @@ namespace fuzzuf::algorithm::afl {
 
 class AFLHavocOptimizer : public optimizer::HavocOptimizer {
  public:
-  AFLHavocOptimizer(std::shared_ptr<optimizer::Optimizer<u32>> mutop_optimizer, int havoc_stack_pow);
+  AFLHavocOptimizer(std::shared_ptr<optimizer::Optimizer<u32>> mutop_optimizer,
+                    int havoc_stack_pow);
   virtual ~AFLHavocOptimizer();
 
   u32 CalcMutop(u32 batch_idx) override;

--- a/include/fuzzuf/algorithms/afl/afl_havoc_optimizer.hpp
+++ b/include/fuzzuf/algorithms/afl/afl_havoc_optimizer.hpp
@@ -29,7 +29,7 @@ namespace fuzzuf::algorithm::afl {
 
 class AFLHavocOptimizer : public optimizer::HavocOptimizer {
  public:
-  AFLHavocOptimizer(std::shared_ptr<optimizer::Optimizer<u32>> mutop_optimizer);
+  AFLHavocOptimizer(std::shared_ptr<optimizer::Optimizer<u32>> mutop_optimizer, int havoc_stack_pow);
   virtual ~AFLHavocOptimizer();
 
   u32 CalcMutop(u32 batch_idx) override;
@@ -39,6 +39,7 @@ class AFLHavocOptimizer : public optimizer::HavocOptimizer {
   void UpdateInternalState() override;
 
   std::shared_ptr<optimizer::Optimizer<u32>> mutop_optimizer;
+  int havoc_stack_pow;
 };
 
 }  // namespace fuzzuf::algorithm::afl

--- a/include/fuzzuf/cli/fuzzer/afl/build_afl_fuzzer_from_args.hpp
+++ b/include/fuzzuf/cli/fuzzer/afl/build_afl_fuzzer_from_args.hpp
@@ -242,8 +242,10 @@ std::unique_ptr<TFuzzer> BuildFuzzer(
   using algorithm::afl::AFLHavocOptimizer;
   using algorithm::afl::option::GetHavocStackPow2;
 
-  auto mutop_optimizer = std::shared_ptr<optimizer::Optimizer<u32>>(new AFLHavocCaseDistrib());
-  std::unique_ptr<optimizer::HavocOptimizer> havoc_optimizer(new AFLHavocOptimizer(mutop_optimizer, GetHavocStackPow2<AFLTag>()));
+  auto mutop_optimizer =
+      std::shared_ptr<optimizer::Optimizer<u32>>(new AFLHavocCaseDistrib());
+  std::unique_ptr<optimizer::HavocOptimizer> havoc_optimizer(
+      new AFLHavocOptimizer(mutop_optimizer, GetHavocStackPow2<AFLTag>()));
 
   // Create AFLState
   using fuzzuf::algorithm::afl::AFLState;

--- a/include/fuzzuf/cli/fuzzer/afl/build_afl_fuzzer_from_args.hpp
+++ b/include/fuzzuf/cli/fuzzer/afl/build_afl_fuzzer_from_args.hpp
@@ -238,10 +238,12 @@ std::unique_ptr<TFuzzer> BuildFuzzer(
       EXIT("Unsupported executor: '%s'", global_options.executor.c_str());
   }
 
-  auto mutop_optimizer = std::shared_ptr<optimizer::Optimizer<u32>>(
-      new algorithm::afl::AFLHavocCaseDistrib());
-  std::unique_ptr<optimizer::HavocOptimizer> havoc_optimizer(
-      new algorithm::afl::AFLHavocOptimizer(mutop_optimizer));
+  using algorithm::afl::AFLHavocCaseDistrib;
+  using algorithm::afl::AFLHavocOptimizer;
+  using algorithm::afl::option::GetHavocStackPow2;
+
+  auto mutop_optimizer = std::shared_ptr<optimizer::Optimizer<u32>>(new AFLHavocCaseDistrib());
+  std::unique_ptr<optimizer::HavocOptimizer> havoc_optimizer(new AFLHavocOptimizer(mutop_optimizer, GetHavocStackPow2<AFLTag>()));
 
   // Create AFLState
   using fuzzuf::algorithm::afl::AFLState;

--- a/include/fuzzuf/cli/fuzzer/aflfast/build_aflfast_fuzzer_from_args.hpp
+++ b/include/fuzzuf/cli/fuzzer/aflfast/build_aflfast_fuzzer_from_args.hpp
@@ -220,10 +220,14 @@ std::unique_ptr<TFuzzer> BuildAFLFastFuzzerFromArgs(
 
   using algorithm::afl::AFLHavocCaseDistrib;
   using algorithm::afl::AFLHavocOptimizer;
-  using algorithm::afl::option::GetHavocStackPow2;;
+  using algorithm::afl::option::GetHavocStackPow2;
+  ;
 
-  auto mutop_optimizer = std::unique_ptr<optimizer::Optimizer<u32>>(new AFLHavocCaseDistrib());
-  std::unique_ptr<optimizer::HavocOptimizer> havoc_optimizer(new AFLHavocOptimizer(std::move(mutop_optimizer), GetHavocStackPow2<AFLFastTag>()));
+  auto mutop_optimizer =
+      std::unique_ptr<optimizer::Optimizer<u32>>(new AFLHavocCaseDistrib());
+  std::unique_ptr<optimizer::HavocOptimizer> havoc_optimizer(
+      new AFLHavocOptimizer(std::move(mutop_optimizer),
+                            GetHavocStackPow2<AFLFastTag>()));
 
   // Create AFLFastState
   using fuzzuf::algorithm::aflfast::AFLFastState;

--- a/include/fuzzuf/cli/fuzzer/aflfast/build_aflfast_fuzzer_from_args.hpp
+++ b/include/fuzzuf/cli/fuzzer/aflfast/build_aflfast_fuzzer_from_args.hpp
@@ -218,10 +218,12 @@ std::unique_ptr<TFuzzer> BuildAFLFastFuzzerFromArgs(
       EXIT("Unsupported executor: '%s'", global_options.executor.c_str());
   }
 
-  auto mutop_optimizer = std::unique_ptr<optimizer::Optimizer<u32>>(
-      new algorithm::afl::AFLHavocCaseDistrib());
-  std::unique_ptr<optimizer::HavocOptimizer> havoc_optimizer(
-      new algorithm::afl::AFLHavocOptimizer(std::move(mutop_optimizer)));
+  using algorithm::afl::AFLHavocCaseDistrib;
+  using algorithm::afl::AFLHavocOptimizer;
+  using algorithm::afl::option::GetHavocStackPow2;;
+
+  auto mutop_optimizer = std::unique_ptr<optimizer::Optimizer<u32>>(new AFLHavocCaseDistrib());
+  std::unique_ptr<optimizer::HavocOptimizer> havoc_optimizer(new AFLHavocOptimizer(std::move(mutop_optimizer), GetHavocStackPow2<AFLFastTag>()));
 
   // Create AFLFastState
   using fuzzuf::algorithm::aflfast::AFLFastState;

--- a/include/fuzzuf/cli/fuzzer/aflplusplus/build_aflplusplus_fuzzer_from_args.hpp
+++ b/include/fuzzuf/cli/fuzzer/aflplusplus/build_aflplusplus_fuzzer_from_args.hpp
@@ -284,10 +284,12 @@ std::unique_ptr<TFuzzer> BuildAFLplusplusFuzzerFromArgs(
         AFLPLUSPLUS_NUM_CASE, GetMaxFile<AFLplusplusTag>(),
         GetHavocStackPow2<AFLplusplusTag>()));
   } else {
-    std::unique_ptr<optimizer::Optimizer<u32>> mutop_optimizer(
-        new algorithm::aflplusplus::havoc::AFLplusplusHavocCaseDistrib());
-    havoc_optimizer.reset(
-        new algorithm::afl::AFLHavocOptimizer(std::move(mutop_optimizer)));
+    using algorithm::aflplusplus::havoc::AFLplusplusHavocCaseDistrib;
+    using algorithm::afl::AFLHavocOptimizer;
+    using algorithm::afl::option::GetHavocStackPow2;
+
+    std::unique_ptr<optimizer::Optimizer<u32>> mutop_optimizer(new AFLplusplusHavocCaseDistrib());
+    havoc_optimizer.reset(new AFLHavocOptimizer(std::move(mutop_optimizer), GetHavocStackPow2<AFLplusplusTag>()));
   }
 
   // Create AFLplusplusState

--- a/include/fuzzuf/cli/fuzzer/aflplusplus/build_aflplusplus_fuzzer_from_args.hpp
+++ b/include/fuzzuf/cli/fuzzer/aflplusplus/build_aflplusplus_fuzzer_from_args.hpp
@@ -284,12 +284,14 @@ std::unique_ptr<TFuzzer> BuildAFLplusplusFuzzerFromArgs(
         AFLPLUSPLUS_NUM_CASE, GetMaxFile<AFLplusplusTag>(),
         GetHavocStackPow2<AFLplusplusTag>()));
   } else {
-    using algorithm::aflplusplus::havoc::AFLplusplusHavocCaseDistrib;
     using algorithm::afl::AFLHavocOptimizer;
     using algorithm::afl::option::GetHavocStackPow2;
+    using algorithm::aflplusplus::havoc::AFLplusplusHavocCaseDistrib;
 
-    std::unique_ptr<optimizer::Optimizer<u32>> mutop_optimizer(new AFLplusplusHavocCaseDistrib());
-    havoc_optimizer.reset(new AFLHavocOptimizer(std::move(mutop_optimizer), GetHavocStackPow2<AFLplusplusTag>()));
+    std::unique_ptr<optimizer::Optimizer<u32>> mutop_optimizer(
+        new AFLplusplusHavocCaseDistrib());
+    havoc_optimizer.reset(new AFLHavocOptimizer(
+        std::move(mutop_optimizer), GetHavocStackPow2<AFLplusplusTag>()));
   }
 
   // Create AFLplusplusState

--- a/include/fuzzuf/cli/fuzzer/ijon/build_ijon_fuzzer_from_args.hpp
+++ b/include/fuzzuf/cli/fuzzer/ijon/build_ijon_fuzzer_from_args.hpp
@@ -179,12 +179,15 @@ std::unique_ptr<TFuzzer> BuildIJONFuzzerFromArgs(
       EXIT("Unsupported executor: '%s'", global_options.executor.c_str());
   }
 
-  using algorithm::ijon::havoc::IJONHavocCaseDistrib;
   using algorithm::afl::AFLHavocOptimizer;
   using algorithm::afl::option::GetHavocStackPow2;
+  using algorithm::ijon::havoc::IJONHavocCaseDistrib;
 
-  auto mutop_optimizer = std::unique_ptr<optimizer::Optimizer<u32>>(new IJONHavocCaseDistrib());
-  std::unique_ptr<optimizer::HavocOptimizer> havoc_optimizer(new AFLHavocOptimizer(std::move(mutop_optimizer), GetHavocStackPow2<IJONTag>()));
+  auto mutop_optimizer =
+      std::unique_ptr<optimizer::Optimizer<u32>>(new IJONHavocCaseDistrib());
+  std::unique_ptr<optimizer::HavocOptimizer> havoc_optimizer(
+      new AFLHavocOptimizer(std::move(mutop_optimizer),
+                            GetHavocStackPow2<IJONTag>()));
 
   // Create IJONState
   using fuzzuf::algorithm::ijon::IJONState;

--- a/include/fuzzuf/cli/fuzzer/ijon/build_ijon_fuzzer_from_args.hpp
+++ b/include/fuzzuf/cli/fuzzer/ijon/build_ijon_fuzzer_from_args.hpp
@@ -179,10 +179,12 @@ std::unique_ptr<TFuzzer> BuildIJONFuzzerFromArgs(
       EXIT("Unsupported executor: '%s'", global_options.executor.c_str());
   }
 
-  auto mutop_optimizer = std::unique_ptr<optimizer::Optimizer<u32>>(
-      new algorithm::ijon::havoc::IJONHavocCaseDistrib());
-  std::unique_ptr<optimizer::HavocOptimizer> havoc_optimizer(
-      new algorithm::afl::AFLHavocOptimizer(std::move(mutop_optimizer)));
+  using algorithm::ijon::havoc::IJONHavocCaseDistrib;
+  using algorithm::afl::AFLHavocOptimizer;
+  using algorithm::afl::option::GetHavocStackPow2;
+
+  auto mutop_optimizer = std::unique_ptr<optimizer::Optimizer<u32>>(new IJONHavocCaseDistrib());
+  std::unique_ptr<optimizer::HavocOptimizer> havoc_optimizer(new AFLHavocOptimizer(std::move(mutop_optimizer), GetHavocStackPow2<IJONTag>()));
 
   // Create IJONState
   using fuzzuf::algorithm::ijon::IJONState;

--- a/include/fuzzuf/cli/fuzzer/mopt/build_mopt_fuzzer_from_args.hpp
+++ b/include/fuzzuf/cli/fuzzer/mopt/build_mopt_fuzzer_from_args.hpp
@@ -238,7 +238,8 @@ std::unique_ptr<TFuzzer> BuildMOptFuzzerFromArgs(
   using algorithm::afl::option::GetHavocStackPow2;
 
   auto mutop_optimizer = std::make_shared<optimizer::MOptOptimizer>();
-  std::unique_ptr<optimizer::HavocOptimizer> havoc_optimizer(new AFLHavocOptimizer(mutop_optimizer, GetHavocStackPow2<MOptTag>()));
+  std::unique_ptr<optimizer::HavocOptimizer> havoc_optimizer(
+      new AFLHavocOptimizer(mutop_optimizer, GetHavocStackPow2<MOptTag>()));
 
   // Create MOptState
   using fuzzuf::algorithm::mopt::MOptState;

--- a/include/fuzzuf/cli/fuzzer/mopt/build_mopt_fuzzer_from_args.hpp
+++ b/include/fuzzuf/cli/fuzzer/mopt/build_mopt_fuzzer_from_args.hpp
@@ -234,9 +234,11 @@ std::unique_ptr<TFuzzer> BuildMOptFuzzerFromArgs(
       EXIT("Unsupported executor: '%s'", global_options.executor.c_str());
   }
 
+  using algorithm::afl::AFLHavocOptimizer;
+  using algorithm::afl::option::GetHavocStackPow2;
+
   auto mutop_optimizer = std::make_shared<optimizer::MOptOptimizer>();
-  std::unique_ptr<optimizer::HavocOptimizer> havoc_optimizer(
-      new algorithm::afl::AFLHavocOptimizer(mutop_optimizer));
+  std::unique_ptr<optimizer::HavocOptimizer> havoc_optimizer(new AFLHavocOptimizer(mutop_optimizer, GetHavocStackPow2<MOptTag>()));
 
   // Create MOptState
   using fuzzuf::algorithm::mopt::MOptState;


### PR DESCRIPTION
<!-- Set a title that summarizes the PR changes. -->

## Type of PR
<!-- This project uses issue-driven development, so please take the appropriate action for each PR type. -->

- [ ] Changes related to the roadmap (e.g., TODO.md) (type: A) -> Create an issue corresponding to the PR in advance, and refer to this PR in the issue.
- Changes that are not related to the roadmap
    - [ ] Change with multiple possible solutions to the issue (type: B-1) -> Create an issue corresponding to the PR in advance and refer to this PR in the issue.
    - [x] Change with a single solution (type: B-2) -> There is no need to create an issue corresponding to the PR in advance. Please discuss it in this PR.

## Related Issue
<!-- If this PR is a PR type A/B-1, please provide a link to the corresponding issue. -->
<!-- If this PR is a PR type B-1, please write "N/A" -->

## Importance of PR
<!-- Please describe the importance of the PR in terms of the following aspects. -->

- Importance of the issue
    - [ ] Large (based on several days to weeks of discussion and verification, e.g., this issue is a blocking issue for other issues on the roadmap, etc.)
    - [x] Medium (based on a few hours to a day of discussion and verification, e.g., this issue is a blocking issue for another minor issue)
    - [ ] Small (apparent changes such as build error)
- Complexity of the solution (code, tests, etc.)
    - [ ] Large (requires several days to several weeks of review)
    - [ ] Medium (requires several hours to a day of review)
    - [x] Small (trivial changes, such as build error)

## PR Overview
<!-- Please provide a summary of this PR. -->
<!-- If this PR is a PR type A/B-1, this PR will be considered as an item in the checklist for the related issue. Please provide a link to the issue comment that contains the checklist. -->
<!-- If this PR is a PR type B-2, unnecessary to reference the issue. Please provide a summary. -->

While `afl::option::GetHavocStackPow2<aflplusplus::option::AFLplusplusTag>` is overridden in https://github.com/fuzzuf/fuzzuf/pull/99, actually it's not used :(

https://github.com/fuzzuf/fuzzuf/blob/6c930ad141f1e9fcfe281e1c48a10fd37229cc74/algorithms/afl_common/afl_havoc_optimizer.cpp#L41
https://github.com/fuzzuf/fuzzuf/blob/6c930ad141f1e9fcfe281e1c48a10fd37229cc74/include/fuzzuf/cli/fuzzer/aflplusplus/build_aflplusplus_fuzzer_from_args.hpp#L290

## Concerns (Optional)
<!-- If you have any concerns, please describe them clearly by filling in the relevant checklist items below. If there is anything else you would like to share with the reviewer, please include it. -->

I have one thing to discuss (there is no need to deal with it in this PR though).
This kind of bug (something, that we thought was used, is actually not used) is common to fuzzuf (e.g., this one, or https://github.com/fuzzuf/fuzzuf/pull/72).
This means that we should have a countermeasure for this if possible, and probably that tests are not enough.
Any idea for the measures? At least I think we should dump these configure values to a log so that we can get aware of it being unchanged.

- [ ] Performance
- [ ] Source Code Quality

---

> The PR author should fill in the following checklist when submitting this PR.

#### Optional Entries
- [ ] If this PR is a PR type A/B-1, there is a cross-link between this PR and the related issue.

#### Mandatory Entries
- [ ] The PR title is a summary of the changes.
- [ ] Completed each required field of the PR.

---
> The PR author should fill out the following checklist in the comments to confirm that this PR is ready to be merged

- [ ] CI is green or confirmed test run results.
- [ ] All change suggestions from reviewers have been resolved (fixed or foregone).

---
> The maintainer of this repository will set up a reviewer for each PR.
> PR reviewers should review this PR in terms of the checklist below before moving on to a detailed code review. Please comment on their initial response by filling in the checklist below.

#### Optional Entries
- [ ] The reviewer assigned more reviewers if needed.
- [ ] The reviewer noted that it is necessary to break out some of the changes in this PR into other PRs if needed.
- [ ] The reviewer noted that the initial response is insufficient if needed.

#### Mandatory Entries
- [ ] The title of this PR summarizes the changes made by this PR properly.
- [ ] The target branch of this PR is as intended.
- [ ] The reviewer understands the issues in this PR.
- [ ] The reviewer plans to review with an appropriate workload based on the importance of this PR.

---
> When the PR reviewer concludes that this PR is ready to be merged, please fill in the checklist below by posting it in the comment. If there is more than one reviewer, please do this on your own.

#### Optional Entries
- [ ] The reviewer noted that if you believe that new tests are needed to evaluate this PR, they have been noted.
- [ ] If minor refactorings are not mentioned in the PR, I understand the intent.
- [ ] If this PR is a PR type A/B-1, we have agreed on this PR's design, direction, and granularity in the related issue.

#### Mandatory Entries
- [ ] The reviewer understands how this PR addresses the issue and the specific changes.
- [ ] This PR uses the best possible issue resolution that the reviewer can think of.
- [ ] This PR is ready to be merged.
