### PR TITLE
Fix use of uninitialized value in `fuzzuf aflplusplus` options

### DIFF
--- a/include/fuzzuf/cli/fuzzer/aflplusplus/build_aflplusplus_fuzzer_from_args.hpp
+++ b/include/fuzzuf/cli/fuzzer/aflplusplus/build_aflplusplus_fuzzer_from_args.hpp
@@ -51,17 +51,14 @@ namespace fuzzuf::cli::fuzzer::aflplusplus {
 namespace po = boost::program_options;
 
 struct AFLplusplusFuzzerOptions {
-  bool forksrv;                        // Optional
-  std::vector<std::string> dict_file;  // Optional
-  bool frida_mode;                     // Optional
-  bool use_slopt;                      // Optional
-  std::string schedule;                // Optional
-  std::string instance_id;             // Optional
+  bool forksrv = true;                      
+  std::vector<std::string> dict_file;
+  bool frida_mode = false;                   
+  bool use_slopt = false;                    
+  std::string schedule = "fast";              
+  std::string instance_id;           
   utils::ParallelModeT parallel_mode =
-      utils::ParallelModeT::SINGLE;  // Optional
-  // Default values
-  AFLplusplusFuzzerOptions()
-      : forksrv(true), frida_mode(false), schedule("fast"){};
+      utils::ParallelModeT::SINGLE;
 };
 
 // Fuzzer specific help


### PR DESCRIPTION
<!-- Set a title that summarizes the PR changes. -->

## Type of PR
<!-- This project uses issue-driven development, so please take the appropriate action for each PR type. -->

- [ ] Changes related to the roadmap (e.g., TODO.md) (type: A) -> Create an issue corresponding to the PR in advance, and refer to this PR in the issue.
- Changes that are not related to the roadmap
    - [ ] Change with multiple possible solutions to the issue (type: B-1) -> Create an issue corresponding to the PR in advance and refer to this PR in the issue.
    - [x] Change with a single solution (type: B-2) -> There is no need to create an issue corresponding to the PR in advance. Please discuss it in this PR.

## Related Issue
<!-- If this PR is a PR type A/B-1, please provide a link to the corresponding issue. -->
<!-- If this PR is a PR type B-1, please write "N/A" -->

## Importance of PR
<!-- Please describe the importance of the PR in terms of the following aspects. -->

- Importance of the issue
    - [ ] Large (based on several days to weeks of discussion and verification, e.g., this issue is a blocking issue for other issues on the roadmap, etc.)
    - [ ] Medium (based on a few hours to a day of discussion and verification, e.g., this issue is a blocking issue for another minor issue)
    - [x] Small (apparent changes such as build error)
- Complexity of the solution (code, tests, etc.)
    - [ ] Large (requires several days to several weeks of review)
    - [ ] Medium (requires several hours to a day of review)
    - [x] Small (trivial changes, such as build error)

## PR Overview
<!-- Please provide a summary of this PR. -->
<!-- If this PR is a PR type A/B-1, this PR will be considered as an item in the checklist for the related issue. Please provide a link to the issue comment that contains the checklist. -->
<!-- If this PR is a PR type B-2, unnecessary to reference the issue. Please provide a summary. -->

While I was taking some benchmark, I realized that `fuzzuf aflplusplus` randomly changes its behavior and shows obviously different performance.
After debugging a while, I realized that `use_slopt` option is uninitialized and hence sometimes SLOPT is enabled even if we don't specify it in launching `fuzzuf aflplusplus`.

## Concerns (Optional)
<!-- If you have any concerns, please describe them clearly by filling in the relevant checklist items below. If there is anything else you would like to share with the reviewer, please include it. -->

- [ ] Performance
- [ ] Source Code Quality

---

> The PR author should fill in the following checklist when submitting this PR.

#### Optional Entries
- [ ] If this PR is a PR type A/B-1, there is a cross-link between this PR and the related issue.

#### Mandatory Entries
- [x] The PR title is a summary of the changes.
- [x] Completed each required field of the PR.

---
> The PR author should fill out the following checklist in the comments to confirm that this PR is ready to be merged

- [ ] CI is green or confirmed test run results.
- [ ] All change suggestions from reviewers have been resolved (fixed or foregone).

---
> The maintainer of this repository will set up a reviewer for each PR.
> PR reviewers should review this PR in terms of the checklist below before moving on to a detailed code review. Please comment on their initial response by filling in the checklist below.

#### Optional Entries
- [ ] The reviewer assigned more reviewers if needed.
- [ ] The reviewer noted that it is necessary to break out some of the changes in this PR into other PRs if needed.
- [ ] The reviewer noted that the initial response is insufficient if needed.

#### Mandatory Entries
- [ ] The title of this PR summarizes the changes made by this PR properly.
- [ ] The target branch of this PR is as intended.
- [ ] The reviewer understands the issues in this PR.
- [ ] The reviewer plans to review with an appropriate workload based on the importance of this PR.

---
> When the PR reviewer concludes that this PR is ready to be merged, please fill in the checklist below by posting it in the comment. If there is more than one reviewer, please do this on your own.

#### Optional Entries
- [ ] The reviewer noted that if you believe that new tests are needed to evaluate this PR, they have been noted.
- [ ] If minor refactorings are not mentioned in the PR, I understand the intent.
- [ ] If this PR is a PR type A/B-1, we have agreed on this PR's design, direction, and granularity in the related issue.

#### Mandatory Entries
- [ ] The reviewer understands how this PR addresses the issue and the specific changes.
- [ ] This PR uses the best possible issue resolution that the reviewer can think of.
- [ ] This PR is ready to be merged.
